### PR TITLE
Flying Circus NixOS-related blog posts

### DIFF
--- a/nixos-org/planet-feeds.nix
+++ b/nixos-org/planet-feeds.nix
@@ -47,4 +47,8 @@
     feedUrl ="http://anderspapitto.com/tags/atom/nixos.xml";
     homepageUrl = "http://anderspapitto.com";
   }
+  { name = "Flying Circus";
+    feedUrl = "http://blog.flyingcircus.io/tag/nixos/feed/";
+    homepageUrl = "http://blog.flyingcircus.io/tag/nixos/";
+  }
 ]


### PR DESCRIPTION
We're going to cover NixOS stuff in our company blog in the future.