### PR TITLE
Add 16.09 channel

### DIFF
--- a/nixos-org/hydra-mirror.nix
+++ b/nixos-org/hydra-mirror.nix
@@ -55,14 +55,16 @@ in
   */
 
   systemd =
-    fold recursiveUpdate {}
-      [ (makeUpdateChannel "nixos-16.03" "nixos/release-16.03/tested")
-        (makeUpdateChannel "nixos-16.03-small" "nixos/release-16.03-small/tested")
-        (makeUpdateChannel "nixos-15.09" "nixos/release-15.09/tested")
-        (makeUpdateChannel "nixos-15.09-small" "nixos/release-15.09-small/tested")
-        (makeUpdateChannel "nixos-unstable" "nixos/trunk-combined/tested")
-        (makeUpdateChannel "nixos-unstable-small" "nixos/unstable-small/tested")
-        (makeUpdateChannel "nixpkgs-unstable" "nixpkgs/trunk/unstable")
-      ];
+    fold recursiveUpdate {} [
+      (makeUpdateChannel "nixos-16.09" "nixos/release-16.09/tested")
+      (makeUpdateChannel "nixos-16.09-small" "nixos/release-16.09-small/tested")
+      (makeUpdateChannel "nixos-16.03" "nixos/release-16.03/tested")
+      (makeUpdateChannel "nixos-16.03-small" "nixos/release-16.03-small/tested")
+      (makeUpdateChannel "nixos-15.09" "nixos/release-15.09/tested")
+      (makeUpdateChannel "nixos-15.09-small" "nixos/release-15.09-small/tested")
+      (makeUpdateChannel "nixos-unstable" "nixos/trunk-combined/tested")
+      (makeUpdateChannel "nixos-unstable-small" "nixos/unstable-small/tested")
+      (makeUpdateChannel "nixpkgs-unstable" "nixpkgs/trunk/unstable")
+    ];
 
 }


### PR DESCRIPTION
Note that `nixos-version` shows `_beta` instead of `_pre` for 16.09.

In last release we also put beta in the channel name, I'd strongly prefer not to do that again.

Switching channel twice per release is painful state handling and especially bad UX since beta channel literally disappear/stagnates once final 16.09 is released.

cc @edolstra 