### PR TITLE
nixos-org: add site wide notice for nixos wiki

### DIFF
--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -154,6 +154,8 @@ in
                 #skins = [ ./wiki-skins ];
                 extraConfig =
                   ''
+                    $wgSiteNotice = "The NixOS wiki is outdated and is being shut down. If you wish to add or improve NixOS documentation, please grab a ticket from the [https://github.com/NixOS/nixpkgs/milestone/8 Move the wiki!] milestone.";
+
                     #$wgEmailConfirmToEdit = true;
 
                     #$wgDebugLogFile = "/tmp/mediawiki_debug_log.txt";


### PR DESCRIPTION
my attempt to create a side wide notice for nixos wiki page

NixOS/nixpkgs#16918

if i correctly understand links bellow this should do the trick:
- https://www.mediawiki.org/wiki/Manual:Interface/Sitenotice
- https://www.mediawiki.org/wiki/Manual:$wgSiteNotice