### PR TITLE
Pass GITHUB_OAUTH_TOKEN for https://github.com/NixOS/nixos-channel-scripts/pull/11

### DIFF
--- a/nixos-org/hydra-mirror.nix
+++ b/nixos-org/hydra-mirror.nix
@@ -23,6 +23,7 @@ let
               # FIXME: use IAM role.
               export AWS_ACCESS_KEY_ID=$(sed 's/aws_access_key_id=\(.*\)/\1/ ; t; d' ~/.aws/credentials)
               export AWS_SECRET_ACCESS_KEY=$(sed 's/aws_secret_access_key=\(.*\)/\1/ ; t; d' ~/.aws/credentials)
+              export GITHUB_OAUTH_TOKEN=$(cat ~/.github/token)
               exec mirror-nixos-branch ${channelName} https://hydra.nixos.org/job/${mainJob}/latest-finished
             ''; # */
           serviceConfig.User = "hydra-mirror";


### PR DESCRIPTION
The `GITHUB_OAUTH_TOKEN` should be a GitHub Personal Access Token with the privileges `repo_deployment` _only_ and none others.