### PR TITLE
NixOS 17.03

### DIFF
--- a/nixos-org/tarball-mirror.nix
+++ b/nixos-org/tarball-mirror.nix
@@ -8,7 +8,7 @@ with lib;
 
 let
 
-  nixosRelease = "16.09";
+  nixosRelease = "17.03";
 
 in
 

--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -82,7 +82,7 @@ in
 
   nix.package = pkgs.nixUnstable;
 
-  nix.nixPath = [ "nixpkgs=https://nixos.org/channels/nixos-16.09-small/nixexprs.tar.xz" ];
+  nix.nixPath = [ "nixpkgs=https://nixos.org/channels/nixos-17.03-small/nixexprs.tar.xz" ];
 
   security.pam.enableSSHAgentAuth = true;
 


### PR DESCRIPTION
As soon as https://hydra.nixos.org/build/51054560 passes we have a stable 17.03 channel bump.

cc @edolstra 