### PR TITLE
Enable HSTS and fixup http:// links

### DIFF
--- a/delft/delft-webserver.nix
+++ b/delft/delft-webserver.nix
@@ -73,7 +73,7 @@ in
 
         { # Catch-all site.
           hostName = "old.nixos.org";
-          globalRedirect = "http://nixos.org/";
+          globalRedirect = "https://nixos.org/";
         }
 
         { hostName = "buildfarm.st.ewi.tudelft.nl";

--- a/delft/hydra-proxy.nix
+++ b/delft/hydra-proxy.nix
@@ -49,7 +49,12 @@ in
     adminAddr = "edolstra@gmail.com";
     hostName = "hydra.nixos.org";
     logFormat = ''"%h %l %u %t \"%r\" %>s %b %D"'';
-    extraConfig = hydraProxyConfig;
+    extraConfig = hydraProxyConfig +
+      ''
+        RewriteEngine On
+        RewriteCond %{HTTPS} off
+        RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+      '';
 
     servedDirs =
       [ { urlPath = "/apache-errors";
@@ -69,6 +74,7 @@ in
           # Required by Catalyst.
           RequestHeader set X-Forwarded-Proto https
           RequestHeader set X-Forwarded-Port 443
+          Header always set Strict-Transport-Security "max-age=86400"
         '';
       }
     ];

--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -40,7 +40,7 @@ let
         ''
           MaxKeepAliveRequests 0
 
-          Redirect /binary-cache http://cache.nixos.org
+          Redirect /binary-cache https://cache.nixos.org
           Redirect /releases/channels /channels
           Redirect /tarballs http://tarballs.nixos.org
           Redirect /releases/nixos https://d3g5gsiof5omrk.cloudfront.net/nixos
@@ -116,7 +116,7 @@ in
     virtualHosts =
       [ { # Catch-all site.
           hostName = "www.nixos.org";
-          globalRedirect = "http://nixos.org/";
+          globalRedirect = "https://nixos.org/";
         }
 
         (nixosVHostConfig // {
@@ -144,7 +144,7 @@ in
               UseCanonicalName on
 
               # We don't want /channels to be cached by CloudFront.
-              Redirect /channels http://nixos.org/channels
+              Redirect /channels https://nixos.org/channels
             '';
           servedDirs =
             [ { urlPath = "/";

--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -49,6 +49,10 @@ let
           RewriteEngine on
           RewriteRule "^(.*/)?\.git/" - [F,L]
 
+          # Rewrite HTTP to HTTPS
+          RewriteCond %{HTTPS} off
+          RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
           RedirectMatch "^/wiki.*" "https://nixos.org/nixos/wiki.html"
 
           <Location /server-status>
@@ -129,6 +133,7 @@ in
           sslServerCert = "${acmeKeyDir}/fullchain.pem";
           extraConfig = nixosVHostConfig.extraConfig +
             ''
+              Header always set Strict-Transport-Security "max-age=86400"
               SSLProtocol All -SSLv2 -SSLv3
               SSLCipherSuite HIGH:!aNULL:!MD5:!EXP
               SSLHonorCipherOrder on


### PR DESCRIPTION
HSTS tells the browser that you should always use HTTPS when
talking to the domain, for the next max-age. This means it will
(in-browser) redirect from http to https, without hitting a
the webserver.

 - max-age is set to 1 day in case of problems, in the future I'd
   like to extend this.
 - we can't enable includeSubdomains because the following
   domains don't use TLS:

   - www.nixos.org (redirects to nixos.org)
   - releases.nixos.org (deprecated? how much traffic does this get?)
   - planet.nixos.org

  If we can fix these, we can add includeSubdomains too.

Obviously I haven't tested this, as I don't have a local copy of
nixos.org running :)