### PR TITLE
hsts: increase age to 6 months

### DIFF
--- a/delft/hydra-proxy.nix
+++ b/delft/hydra-proxy.nix
@@ -74,7 +74,7 @@ in
           # Required by Catalyst.
           RequestHeader set X-Forwarded-Proto https
           RequestHeader set X-Forwarded-Port 443
-          Header always set Strict-Transport-Security "max-age=86400"
+          Header always set Strict-Transport-Security "max-age=15552000"
         '';
       }
     ];

--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -133,7 +133,7 @@ in
           sslServerCert = "${acmeKeyDir}/fullchain.pem";
           extraConfig = nixosVHostConfig.extraConfig +
             ''
-              Header always set Strict-Transport-Security "max-age=86400"
+              Header always set Strict-Transport-Security "max-age=15552000"
               SSLProtocol All -SSLv2 -SSLv3
               SSLCipherSuite HIGH:!aNULL:!MD5:!EXP
               SSLHonorCipherOrder on


### PR DESCRIPTION
6mo is long enough we are a step closer to being able to "preload" hsts support. After this, we'd need to ensure all subdomains supported HSTS. Do you have a list?

 - releases.nixos.org
 - planet.nixos.org
 - hydra.nixos.org
 - test.nixos.org
 - test2.nixos.org
 - ipv6.nixos.org

anything I missed?