### PR TITLE
www.nixos.org: serve an SSL certificate

### DIFF
--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -318,6 +318,7 @@ in
     ''
       ${mkKeys "${acmeKeyDir}/nixos.org"}
       ${mkKeys "${acmeKeyDir}/planet.nixos.org"}
+      ${mkKeys "${acmeKeyDir}/www.nixos.org"}
     '';
 
 }

--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -123,6 +123,29 @@ in
           globalRedirect = "https://nixos.org/";
         }
 
+        { # Catch-all site, SSL
+          hostName = "www.nixos.org";
+          globalRedirect = "https://nixos.org/";
+
+          enableSSL = true;
+          sslServerKey = "${acmeKeyDir}/www.nixos.org/key.pem";
+          sslServerCert = "${acmeKeyDir}/www.nixos.org/fullchain.pem";
+          extraConfig = nixosVHostConfig.extraConfig +
+            ''
+              Header always set Strict-Transport-Security "max-age=15552000"
+              SSLProtocol All -SSLv2 -SSLv3
+              SSLCipherSuite HIGH:!aNULL:!MD5:!EXP
+              SSLHonorCipherOrder on
+              #SSLOpenSSLConfCmd DHParameters "${./dhparams.pem}"
+            '';
+          servedDirs =
+            [ { urlPath = "/.well-known/acme-challenge";
+                dir = "${acmeWebRoot}/.well-known/acme-challenge";
+              }
+           ];
+
+        }
+
         (nixosVHostConfig // {
           extraConfig = nixosVHostConfig.extraConfig;
         })
@@ -263,6 +286,11 @@ in
         postRun = "systemctl reload httpd.service";
       };
     "planet.nixos.org" =
+      { email = "edolstra@gmail.com";
+        webroot = "${acmeWebRoot}";
+        postRun = "systemctl reload httpd.service";
+      };
+    "www.nixos.org" =
       { email = "edolstra@gmail.com";
         webroot = "${acmeWebRoot}";
         postRun = "systemctl reload httpd.service";


### PR DESCRIPTION
Currently https://www.nixos.org/ is an SSL certificate CN mismatch error page. :(