### PR TITLE
terraform releases bucket

### DIFF
--- a/terraform/releases.tf
+++ b/terraform/releases.tf
@@ -1,5 +1,13 @@
 resource "aws_s3_bucket" "releases" {
   bucket = "nix-releases"
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["HEAD", "GET"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
 }
 
 resource "aws_cloudfront_distribution" "releases" {

--- a/terraform/releases.tf
+++ b/terraform/releases.tf
@@ -1,3 +1,7 @@
+resource "aws_s3_bucket" "releases" {
+  bucket = "nix-releases"
+}
+
 resource "aws_cloudfront_distribution" "releases" {
   enabled         = true
   is_ipv6_enabled = true
@@ -6,7 +10,7 @@ resource "aws_cloudfront_distribution" "releases" {
 
   origin {
     origin_id   = "default"
-    domain_name = "nix-releases.s3.amazonaws.com"
+    domain_name = "${aws_s3_bucket.releases.bucket_regional_domain_name}"
 
     s3_origin_config {
       origin_access_identity = ""


### PR DESCRIPTION
I wanted to build a JavaScript-only version of howoldis.herokuapp.com but this requires some CORS enabled on the releases bucket.

Run this command to import the existing bucket into the state:

    terraform import aws_s3_bucket.releases nix-releases