### PR TITLE
terraform: update the bucket policies

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -25,7 +25,53 @@ resource "aws_s3_bucket_policy" "cache" {
 
   # imported from existing
   policy = <<EOF
-{"Version":"2008-10-17","Statement":[{"Sid":"AllowPublicRead","Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::nix-cache/*"},{"Sid":"AllowUploadDebuginfoWrite","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::080433136561:user/s3-upload-releases"},"Action":["s3:PutObject","s3:PutObjectAcl"],"Resource":"arn:aws:s3:::nix-cache/debuginfo/*"},{"Sid":"AllowUploadDebuginfoRead","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::080433136561:user/s3-upload-releases"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::nix-cache/*"},{"Sid":"AllowUploadDebuginfoRead2","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::080433136561:user/s3-upload-releases"},"Action":["s3:ListBucket","s3:GetBucketLocation"],"Resource":"arn:aws:s3:::nix-cache"}]}
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPublicRead",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::nix-cache/*"
+    },
+    {
+      "Sid": "AllowUploadDebuginfoWrite",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-releases"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::nix-cache/debuginfo/*"
+    },
+    {
+      "Sid": "AllowUploadDebuginfoRead",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-releases"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::nix-cache/*"
+    },
+    {
+      "Sid": "AllowUploadDebuginfoRead2",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-releases"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::nix-cache"
+    }
+  ]
+}
 EOF
 }
 

--- a/terraform/nixpkgs-tarballs.tf
+++ b/terraform/nixpkgs-tarballs.tf
@@ -11,7 +11,104 @@ resource "aws_s3_bucket_policy" "nixpkgs-tarballs" {
 
   # imported from existing
   policy = <<EOF
-{"Version":"2008-10-17","Statement":[{"Sid":"AllowPublicRead","Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::nixpkgs-tarballs/*"},{"Sid":"AllowUpload","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::080433136561:user/s3-upload-tarballs"},"Action":["s3:PutObject","s3:PutObjectAcl"],"Resource":"arn:aws:s3:::nixpkgs-tarballs/*"},{"Sid":"AllowUpload2","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::080433136561:user/s3-upload-tarballs"},"Action":"s3:ListBucket","Resource":"arn:aws:s3:::nixpkgs-tarballs"},{"Sid":"CopumpkinAllowUpload","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::390897850978:root"},"Action":["s3:PutObject","s3:PutObjectAcl"],"Resource":"arn:aws:s3:::nixpkgs-tarballs/*"},{"Sid":"CopumpkinAllowUpload2","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::390897850978:root"},"Action":"s3:ListBucket","Resource":"arn:aws:s3:::nixpkgs-tarballs"},{"Sid":"ShlevyAllowUpload","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::976576280863:user/shlevy"},"Action":["s3:PutObject","s3:PutObjectAcl"],"Resource":"arn:aws:s3:::nixpkgs-tarballs/*"},{"Sid":"ShlevyAllowUpload2","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::976576280863:user/shlevy"},"Action":"s3:ListBucket","Resource":"arn:aws:s3:::nixpkgs-tarballs"},{"Sid":"DaiderdAllowUpload","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::014292808257:user/lnl7"},"Action":["s3:PutObject","s3:PutObjectAcl"],"Resource":"arn:aws:s3:::nixpkgs-tarballs/*"},{"Sid":"DaiderdAllowUpload2","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::014292808257:user/lnl7"},"Action":"s3:ListBucket","Resource":"arn:aws:s3:::nixpkgs-tarballs"}]}
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPublicRead",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs/*"
+    },
+    {
+      "Sid": "AllowUpload",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-tarballs"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs/*"
+    },
+    {
+      "Sid": "AllowUpload2",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-tarballs"
+      },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs"
+    },
+    {
+      "Sid": "CopumpkinAllowUpload",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::390897850978:root"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs/*"
+    },
+    {
+      "Sid": "CopumpkinAllowUpload2",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::390897850978:root"
+      },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs"
+    },
+    {
+      "Sid": "ShlevyAllowUpload",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::976576280863:user/shlevy"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs/*"
+    },
+    {
+      "Sid": "ShlevyAllowUpload2",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::976576280863:user/shlevy"
+      },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs"
+    },
+    {
+      "Sid": "DaiderdAllowUpload",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::014292808257:user/lnl7"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs/*"
+    },
+    {
+      "Sid": "DaiderdAllowUpload2",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::014292808257:user/lnl7"
+      },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::nixpkgs-tarballs"
+    }
+  ]
+}
 EOF
 }
 

--- a/terraform/releases.tf
+++ b/terraform/releases.tf
@@ -12,20 +12,55 @@ resource "aws_s3_bucket" "releases" {
 
 resource "aws_s3_bucket_policy" "releases" {
   bucket = "${aws_s3_bucket.releases.id}"
-  policy = "${data.aws_iam_policy_document.releases.json}"
-}
-
-data "aws_iam_policy_document" "releases" {
-  statement {
-    sid       = "1"
-    actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.releases.arn}/*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPublicRead",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::nix-releases/*"
+    },
+    {
+      "Sid": "AllowUploadDebuginfoWrite",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-releases"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::nix-releases/debuginfo/*"
+    },
+    {
+      "Sid": "AllowUploadDebuginfoRead",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-releases"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::nix-releases/*"
+    },
+    {
+      "Sid": "AllowUploadDebuginfoRead2",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::080433136561:user/s3-upload-releases"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::nix-releases"
     }
-  }
+  ]
+}
+EOF
 }
 
 resource "aws_cloudfront_distribution" "releases" {


### PR DESCRIPTION
Formatted with jq

nix-releases inherits the policy from nix-cache

should fix #70 