### PR TITLE
nixos-org: add redirect to learn page

### DIFF
--- a/nixos-org/webserver.nix
+++ b/nixos-org/webserver.nix
@@ -44,6 +44,8 @@ let
           Redirect /releases/channels /channels
           Redirect /tarballs http://tarballs.nixos.org
           Redirect /releases/nixos https://releases.nixos.org/nixos
+          # Added for https://github.com/NixOS/nixos-homepage/pull/318
+          Redirect /nixos/support.html /nixos/learn.html
 
           # Don't allow access to .git directories.
           RewriteEngine on


### PR DESCRIPTION
Redirect the old page name to the new one.

Apply once https://github.com/NixOS/nixos-homepage/pull/318 has been
merged.