### PR TITLE
status-page: fix race condition in initialization.

### DIFF
--- a/delft/eris/status-page/status.js
+++ b/delft/eris/status-page/status.js
@@ -1,7 +1,12 @@
-window.onload = (_) => {
-    var tbody = document.getElementById("channel-status");
-    tbody.innerHTML = "<tr><td class='jsfallback' colspan='5'>Loading data from Prometheus...</td></tr>";
-};
+function init() {
+  return new Promise(resolve => {
+    window.onload = () => {
+      var tbody = document.getElementById("channel-status");
+      tbody.innerHTML = "<tr><td class='jsfallback' colspan='5'>Loading data from Prometheus...</td></tr>";
+      resolve();
+    };
+  });
+}
 
 function aggregateByChannel(result) {
   return result.reduce((acc, {
@@ -119,7 +124,8 @@ function cmp_channels(left, right) {
   return normalize_channel(left) < normalize_channel(right)
 }
 
-Promise.all([revisionData, updateTimeData, jobsetData])
+init()
+  .then(() => Promise.all([revisionData, updateTimeData, jobsetData]))
   .then(([revisions, update_times, jobsets]) => {
     var combined = [];
 


### PR DESCRIPTION
Due to the fact that loading state text is inserted on window onload,
this insertion can potentially happen **after** all other async
actions are already finished and thus replace the actual data.
This fix makes sure that requests are triggered after onload is done.

cc @grahamc

This is what happens when the async actions are resolved with timing that leads to this issue:

![image](https://user-images.githubusercontent.com/2130305/71913280-59760f00-3177-11ea-84dc-9f4ef42074a5.png)

## Steps to reproduce:

1. make sure that **client side cache is disabled* in browser
    - common way is to set "disable caching while developer console is open" and open the console
1. refresh page several times until you hit critical timing in which issue occures.