### PR TITLE
alertmanager: reduce alerts for flipping systemd states

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -141,14 +141,14 @@ in {
             }
             {
               alert = "ChannelUpdateStuck";
-              expr = ''sum(node_systemd_unit_state{name=~"^update-nix.*.service$",state=~"activating|failed"}) without(state) == 1'';
+              expr = ''max_over_time(node_systemd_unit_state{name=~"^update-nix.*.service$",state=~"failed"}[5m]) == 1'';
               for = "30m";
               labels.severity = "page";
               annotations.summary = "https://status.nixos.org/grafana/d/fBW4tL1Wz/scheduled-task-state-channels-website?orgId=1&refresh=10s";
             }
             {
               alert = "HomepageUpdateStuck";
-              expr = ''sum(node_systemd_unit_state{name=~"^update-homepage.*.service$",state=~"activating|failed"}) without(state) == 1'';
+              expr = ''max_over_time(node_systemd_unit_state{name=~"^update-homepage.*.service$",state=~"failed"}[5m]) == 1'';
               for = "30m";
               labels.severity = "page";
               annotations.summary = "https://status.nixos.org/grafana/d/fBW4tL1Wz/scheduled-task-state-channels-website?orgId=1&refresh=10s";


### PR DESCRIPTION
Use the failed status over the last 5m instead of it's current value to
avoid triggering multiple alerts when the status flips briefly.