### PR TITLE
tf/cache: Redirect HTTP to HTTPS

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -94,7 +94,7 @@ resource "aws_cloudfront_distribution" "cache" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     target_origin_id       = "S3-nix-cache"
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000


### PR DESCRIPTION
Currently cache.nixos.org is available over HTTP and HTTPS. This is subpar for a variety of reasons.

This commit introduces the viewer_protocol_policy of redirect-to-https to ensure that all connections happen over TLS.

Docs: https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#viewer_protocol_policy

Related to: #34 