### PR TITLE
add timeout to channel exporter requests

### DIFF
--- a/delft/eris/channel-exporter.py
+++ b/delft/eris/channel-exporter.py
@@ -38,7 +38,7 @@ CHANNEL_REQUEST_FAILURES = Counter(
 def measure_channel(name):
     try:
         with CHANNEL_REQUEST_FAILURES.count_exceptions():
-            result = requests.get(f"https://nixos.org/channels/{name}/git-revision")
+            result = requests.get(f"https://nixos.org/channels/{name}/git-revision", timeout=10)
 
             try:
                 return {

--- a/delft/eris/channel-exporter.py
+++ b/delft/eris/channel-exporter.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse
 from prometheus_client import Counter, Histogram, Gauge, start_http_server, REGISTRY
 import time
 import sys
+import logging
 from pprint import pprint
 import json
 
@@ -56,6 +57,7 @@ def measure_channel(name):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     start_http_server(9402)
 
     with open(sys.argv[1]) as channel_data:


### PR DESCRIPTION
According to the requests documentation there's no default timeout
whatsoever, which means the update loop can get stuck.

> If no timeout is specified explicitly, requests do not time out.

/cc @grahamc