### PR TITLE
Update planet-feeds.nix

### DIFF
--- a/nixos-org/planet-feeds.nix
+++ b/nixos-org/planet-feeds.nix
@@ -107,4 +107,9 @@
     feedUrl = "https://blog.nixbuild.net/index.xml";
     homepageUrl = "https://blog.nixbuild.net";
   }
+  {
+    name = "Guillaume (layus) Maudoux";
+    feedUrl = "https://blog.layus.be/tags/nix.rss";
+    homepageUrl = "https://blog.layus.be";
+  }
 ]


### PR DESCRIPTION
Add @layus blog to the nixos planet.

Only the articles tagged 'nix' should appear in the added feed.