### PR TITLE
hydra-queue-runner-reexporter: remove memory_tokens_in_use

### DIFF
--- a/delft/prometheus/hydra-queue-runner-reexporter.py
+++ b/delft/prometheus/hydra-queue-runner-reexporter.py
@@ -207,11 +207,6 @@ class HydraScrapeImporter:
             "Number of in-progress database updates",
             self.destructive_read("nrActiveDbUpdates")
         )
-        yield self.trivial_gauge(
-            "memory_tokens_in_use",
-            "Number of in-use memory tokens",
-            self.destructive_read("memoryTokensInUse")
-        )
         yield self.trivial_counter(
             "notifications_total",
             "Total number of notifications sent",


### PR DESCRIPTION
The upstream property memoryTokensInUse was removed by cbcf6359 [1] in
NixOS/Hydra#795 [2].

[1]: https://github.com/NixOS/hydra/pull/795/commits/cbcf6359b4b8525ab6252de2c3cc389397183159
[2]: https://github.com/NixOS/hydra/pull/795