### PR TITLE
status-page: fix navbar dropdown

### DIFF
--- a/delft/eris/status-page/index.html
+++ b/delft/eris/status-page/index.html
@@ -33,10 +33,10 @@
             <span class="icon-bar"></span>
           </button>
           <li class="dropdown brand">
-            <a class="dropdown-toggle" href="#" data-toggle="dropdown">
+            <a class="dropdown-toggle" data-target="navbar-dropdown-menu" href="#" data-toggle="dropdown">
               <img src="https://nixos.org/logo/nix-wiki.png" alt="NixOS" class="logo" /> NixOS Status <b class="caret"></b>
             </a>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu" id="navbar-dropdown-menu">
               <li><a href="https://nixos.org">NixOS.org</a></li>
             </ul>
           </li>


### PR DESCRIPTION
Looks like it tries to find element using # selector based on the href attribute:

https://github.com/twbs/bootstrap/blob/v3.4.1/js/dropdown.js#L27

resulting in the following error:

    Uncaught Error: Syntax error, unrecognized expression: #

Explicitly specifying data-target fixes that.

cc @samueldr
