### PR TITLE
delft/prometheus/packet-sd: update to newer buildGoModule

### DIFF
--- a/delft/prometheus/packet-sd.nix
+++ b/delft/prometheus/packet-sd.nix
@@ -1,5 +1,5 @@
-{ buildGo112Module, fetchFromGitHub, lib }:
-buildGo112Module rec {
+{ buildGoModule, fetchFromGitHub, lib }:
+buildGoModule rec {
   pname = "prometheus-packet-sd";
   version = "v0.0.3";
 
@@ -10,13 +10,13 @@ buildGo112Module rec {
     sha256 = "sha256-2k8AsmyhQNNZCzpVt6JdgvI8IFb5pRi4ic6Yn2NqHMM=";
   };
 
-  modSha256 = "sha256-I2QSxtNH5KcY7YBDI5XgoIa3bzGBIhDrxweqc34L0Ug=";
+  vendorSha256 = null;
 
   subPackages = [ "." ];
 
   meta = with lib; {
     description = "Prometheus service discovery for Packet.";
-    homepage = https://github.com/packethost/prometheus-packet-sd;
+    homepage = "https://github.com/packethost/prometheus-packet-sd";
     license = licenses.asl20;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
The previous version stopped working on 20.09 and this should unblock the deployment until https://github.com/NixOS/nixpkgs/pull/104500 / https://github.com/NixOS/nixpkgs/pull/104501 arrive in the stable channel of this box.