### PR TITLE
delft/eris: include Prometheus port in nginx proxy_pass directive

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -45,7 +45,7 @@ in {
       forceSSL = true;
       root = ./eris/status-page;
       locations."/grafana/".proxyPass = "http://${config.services.grafana.addr}:${toString config.services.grafana.port}/";
-      locations."/prometheus".proxyPass = "http://${config.services.prometheus.listenAddress}";
+      locations."/prometheus".proxyPass = "http://${config.services.prometheus.listenAddress}:${toString config.service.prometheus.port}/";
     };
   };
 


### PR DESCRIPTION
In NixOS 20.09, the listenAddress directive was changed to be purely
for the address and not for the address:port combination as previously.

This results in nginx now talking to *itself* using plaintext HTTP on
0.0.0.0. With forceSSL, this means nginx issues a redirect for the
hostname -> the client gets a redirect to
https://0.0.0.0/prometheus/....

Fixes #133