### PR TITLE
Serve grafana and prometheus under monitoring.nixos.org

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -47,6 +47,13 @@ in {
       locations."/grafana/".proxyPass = "http://${config.services.grafana.addr}:${toString config.services.grafana.port}/";
       locations."/prometheus".proxyPass = "http://${config.services.prometheus.listenAddress}:${toString config.services.prometheus.port}";
     };
+    virtualHosts."monitoring.nixos.org" = {
+      enableACME = true;
+      forceSSL = true;
+      locations."/".return = "302 https://status.nixos.org";
+      locations."/prometheus/".proxyPass = "http://${config.services.prometheus.listenAddress}:${toString config.services.prometheus.port}";
+      locations."/grafana/".proxyPass = "http://${config.services.grafana.addr}:${toString config.services.grafana.port}/";
+    };
   };
 
   services.prometheus = {


### PR DESCRIPTION
This is step 2 from the https://github.com/NixOS/nixos-org-configurations/pull/137