### PR TITLE
Add AARCH64 channels for NixOS 20.09

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -31,6 +31,10 @@ rec {
         job = "nixpkgs/nixpkgs-21.05-darwin/darwin-tested";
         current = true;
       };
+      "nixos-21.05-aarch64" = {
+        job = "nixos/release-21.05-aarch64/tested";
+        current = true;
+      };
 
       "nixos-20.09" = {
         job = "nixos/release-20.09/tested";
@@ -42,6 +46,10 @@ rec {
       };
       "nixpkgs-20.09-darwin" = {
         job = "nixpkgs/nixpkgs-20.09-darwin/darwin-tested";
+        current = true;
+      };
+      "nixos-20.09-aarch64" = {
+        job = "nixos/release-20.09-aarch64/tested";
         current = true;
       };
 


### PR DESCRIPTION
This adds a channel for NixOS 20.09 on AArcch64 based on the hydra
jobset that we already have.

The topic of an aarch64 specific channel has come up regular and as
these devices are gaining in popularity will only be discussed more
often.

This had been discussed on the nixpkgs issue tracker: https://github.com/NixOS/nixpkgs/issues/83049