### PR TITLE
mac guest-catalina: include extra.nix if present

### DIFF
--- a/macs/guest-catalina/apply.sh
+++ b/macs/guest-catalina/apply.sh
@@ -96,7 +96,11 @@ echo "%admin ALL = NOPASSWD: ALL" | tee /etc/sudoers.d/passwordless
     rm -f /etc/bashrc
     ln -s /etc/static/bashrc /etc/bashrc
     . /etc/static/bashrc
-    cat /Volumes/CONFIG/darwin-configuration.nix | sudo -u nixos -- tee ~nixos/.nixpkgs/darwin-configuration.nix
+    pushd /Volumes/CONFIG
+    for f in *.nix ; do
+        cat $f | sudo -u nixos -- tee ~nixos/.nixpkgs/$f
+    done
+    popd
 
     while ! sudo -i -H -u nixos -- nix ping-store; do
         cat /var/log/nix-daemon.log

--- a/macs/guest-catalina/darwin-configuration.nix
+++ b/macs/guest-catalina/darwin-configuration.nix
@@ -70,4 +70,6 @@ in
     serviceConfig.StandardErrorPath = "/var/log/prometheus-node-exporter.log";
     serviceConfig.StandardOutPath = "/var/log/prometheus-node-exporter.log";
   };
+
+  imports = lib.optional (builtins.pathExists ./extra.nix) ./extra.nix;
 }


### PR DESCRIPTION
This is a bit of an odd PR, because it's not actually aimed at the machines you provision from this repo. I've been successfully (ab)using the macos hosting setup for spinning up general purpose testing machines and have made a few additions that make that a lot easier. Perhaps you don't want this in your repo (after all, I have not tested it on your setup), but in case you do, here it is... (if you _did_ accept it, it would be one fewer patch I'd have to maintain of course ;)

This addition will simply copy _any_ `*.nix` files found in the `guestConfigDir` across to `.nixpkgs/` via the config image. It also modifies `darwin-configuration.nix` to import an `extra.nix` if it is found alongside. Together these allow for simple customization of the guest system setup.

Now I'm writing this, it occurs to me I've only done it for the `guest-catalina/` config and wonder if you'd want it repeated for the standard `guest/` setup. Though of course, I wouldn't have even tested that one _myself_.

cc @grahamc 