### PR TITLE
tf: remove old CloudFront distributions

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -1,3 +1,7 @@
+locals {
+  cache_domain = "cache.nixos.org"
+}
+
 resource "aws_s3_bucket" "cache" {
   provider = aws.us
   bucket   = "nix-cache"
@@ -95,10 +99,6 @@ resource "aws_s3_bucket_policy" "cache" {
   ]
 }
 EOF
-}
-
-locals {
-  cache_domain = "cache.nixos.org"
 }
 
 resource "fastly_service_v1" "cache" {

--- a/terraform/nixpkgs-tarballs.tf
+++ b/terraform/nixpkgs-tarballs.tf
@@ -1,3 +1,11 @@
+locals {
+  tarballs_domain = "tarballs.nixos.org"
+  # Use the website endpoint because the bucket is configured with website
+  # enabled. This also means we can't use TLS between Fastly and AWS because
+  # the website endpoint only has port 80 open.
+  tarballs_backend = aws_s3_bucket.nixpkgs-tarballs.website_endpoint
+}
+
 resource "aws_s3_bucket" "nixpkgs-tarballs" {
   bucket = "nixpkgs-tarballs"
 
@@ -136,95 +144,9 @@ EOF
 resource "aws_s3_bucket_object" "nixpkgs-tarballs-index" {
   bucket       = aws_s3_bucket.nixpkgs-tarballs.id
   content_type = "text/html"
-  etag         = md5(file("${path.module}/nixpkgs-tarballs/index.html"))
+  etag         = filemd5("${path.module}/nixpkgs-tarballs/index.html")
   key          = "index.html"
   source       = "${path.module}/nixpkgs-tarballs/index.html"
-}
-
-resource "aws_cloudfront_distribution" "nixpkgs-tarballs" {
-  enabled         = true
-  is_ipv6_enabled = true
-  price_class     = "PriceClass_All"
-  aliases         = ["tarballs.nixos.org"]
-
-  # Urgh, can't use an S3 origin because it's configured as a website
-  # (to serve HTTP redirects).
-  /*
-  origin {
-    origin_id   = "default"
-    domain_name = "nixpkgs-tarballs.s3-eu-west-1.amazonaws.com"
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.nixpkgs-tarballs-identity.cloudfront_access_identity_path
-    }
-  }
-  */
-
-  origin {
-    origin_id   = "default"
-    domain_name = "nixpkgs-tarballs.s3-website-eu-west-1.amazonaws.com"
-
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = "http-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
-    }
-  }
-
-  default_cache_behavior {
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
-    target_origin_id       = "default"
-    viewer_protocol_policy = "allow-all"
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
-    }
-  }
-  viewer_certificate {
-    cloudfront_default_certificate = false
-    acm_certificate_arn            = aws_acm_certificate.nixpkgs-tarballs.arn
-    ssl_support_method             = "sni-only"
-  }
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-  logging_config {
-    bucket = "nix-cache-logs.s3.amazonaws.com"
-  }
-}
-
-resource "aws_acm_certificate" "nixpkgs-tarballs" {
-  provider          = aws.us
-  domain_name       = "tarballs.nixos.org"
-  validation_method = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-/*
-resource "aws_cloudfront_origin_access_identity" "nixpkgs-tarballs" {
-  comment = "Cloudfront identity for nixpkgs-tarballs"
-}
-*/
-
-locals {
-  tarballs_domain = "tarballs.nixos.org"
-  # Use the website endpoint because the bucket is configured with website
-  # enabled. This also means we can't use TLS between Fastly and AWS because
-  # the website endpoint only has port 80 open.
-  tarballs_backend = aws_s3_bucket.nixpkgs-tarballs.website_endpoint
 }
 
 resource "fastly_service_v1" "nixpkgs-tarballs" {

--- a/terraform/releases.tf
+++ b/terraform/releases.tf
@@ -78,69 +78,6 @@ resource "aws_s3_bucket_policy" "releases" {
 EOF
 }
 
-resource "aws_cloudfront_distribution" "releases" {
-  enabled             = true
-  is_ipv6_enabled     = true
-  price_class         = "PriceClass_All"
-  aliases             = [local.releases_domain]
-  default_root_object = "index.html"
-
-  origin {
-    origin_id   = "default"
-    domain_name = aws_s3_bucket.releases.bucket_domain_name
-
-    #s3_origin_config {
-    #  origin_access_identity = ""
-
-    #  #origin_access_identity = aws_cloudfront_origin_access_identity.releases.cloudfront_access_identity_path
-    #}
-  }
-
-  default_cache_behavior {
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
-    target_origin_id       = "default"
-    viewer_protocol_policy = "allow-all"
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
-    }
-  }
-
-  viewer_certificate {
-    cloudfront_default_certificate = false
-    acm_certificate_arn            = aws_acm_certificate.releases.arn
-    ssl_support_method             = "sni-only"
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-
-  logging_config {
-    bucket = "nix-cache-logs.s3.amazonaws.com"
-  }
-}
-
-resource "aws_acm_certificate" "releases" {
-  provider          = aws.us
-  domain_name       = local.releases_domain
-  validation_method = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "fastly_service_v1" "releases" {
   name        = local.releases_domain
   default_ttl = 86400


### PR DESCRIPTION
Cleanup after switching all the buckets to Fastly.

Waiting a few days in case we need to roll back.