### PR TITLE
terraform: map netlify resources 

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -3,6 +3,79 @@
 locals {
   # Shortcut to keep this a bit leaner
   zone_id = netlify_dns_zone.nixos.id
+
+  dns_records = [
+    {
+      hostname = "bastion.nixos.org"
+      type     = "A"
+      value    = "34.254.208.229"
+    },
+    {
+      hostname = "ceres.nixos.org"
+      type     = "A"
+      value    = "46.4.66.184"
+    },
+    {
+      hostname = "ceres.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:140:244c::"
+    },
+    {
+      hostname = "haumea.nixos.org"
+      type     = "A"
+      value    = "46.4.89.205"
+    },
+    {
+      hostname = "haumea.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:140:72cf::"
+    },
+    {
+      hostname = "hydra.ngi0.nixos.org"
+      type     = "A"
+      value    = "116.202.113.248"
+    },
+    {
+      hostname = "hydra.ngi0.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:231:4187::"
+    },
+    {
+      hostname = "hydra.nixos.org"
+      type     = "A"
+      value    = "46.4.66.184"
+    },
+    {
+      hostname = "hydra.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:140:244c::"
+    },
+    {
+      hostname = "monitoring.nixos.org"
+      type     = "A"
+      value    = "138.201.32.77"
+    },
+    {
+      hostname = "planet.nixos.org"
+      type     = "A"
+      value    = "54.217.220.47"
+    },
+    {
+      hostname = "status.nixos.org"
+      type     = "A"
+      value    = "138.201.32.77"
+    },
+    {
+      hostname = "survey.nixos.org"
+      type     = "A"
+      value    = "78.47.220.153"
+    },
+    {
+      hostname = "survey.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:c0c:6e2c::1"
+    },
+  ]
 }
 
 resource "netlify_dns_zone" "nixos" {
@@ -10,14 +83,28 @@ resource "netlify_dns_zone" "nixos" {
   name    = "nixos.org"
 }
 
-# Import fails with:
+# Import fails on all types with:
 #
 #   Error: &{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
 #
-# resource "netlify_dns_record" "test" {
+# resource "netlify_dns_record" "nixos" {
 #   zone_id  = local.zone_id
 #
 #   hostname = "nixos.org"
 #   type     = "NETLIFY"
 #   value    = "nixos-homepage.netlify.com"
 # }
+#
+# New entries can be created if they are not of NETLIFY type.
+#
+# TTL is not supported.
+
+# netlify api getDnsRecords -d '{ "zone_id": "5e6ce1b8b6f808aa16acd1ff" }'
+
+resource "netlify_dns_record" "nixos" {
+  for_each = { for v in local.dns_records : "${v.hostname}-${v.type}" => v }
+  zone_id  = local.zone_id
+  hostname = each.value.hostname
+  type     = each.value.type
+  value    = each.value.value
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -150,6 +150,16 @@ locals {
       type     = "CNAME"
       value    = "nixos-weekly.netlify.com"
     },
+    {
+      hostname = "_github-challenge-nixos.nixos.org"
+      type     = "TXT"
+      value    = "9e10a04a4b"
+    },
+    {
+      hostname = "nixos.org"
+      type     = "TXT"
+      value    = "v=spf1 include:spf.improvmx.com ~all"
+    },
   ]
 }
 
@@ -182,4 +192,20 @@ resource "netlify_dns_record" "nixos" {
   hostname = each.value.hostname
   type     = each.value.type
   value    = each.value.value
+}
+
+# FIXME: both records have the same priority because the provider doesn't
+# support the "priority" argument.
+resource "netlify_dns_record" "nixos_MX1" {
+  zone_id  = local.zone_id
+  hostname = "nixos.org"
+  type     = "MX"
+  value    = "mx1.improvmx.com"
+}
+
+resource "netlify_dns_record" "nixos_MX2" {
+  zone_id  = local.zone_id
+  hostname = "nixos.org"
+  type     = "MX"
+  value    = "mx2.improvmx.com"
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -75,6 +75,81 @@ locals {
       type     = "AAAA"
       value    = "2a01:4f8:c0c:6e2c::1"
     },
+    {
+      hostname = "_293364b7f7ebb076ac287cd132f8b316.cache.ngi0.nixos.org"
+      type     = "CNAME"
+      value    = "_6a75cfb0c20f4eaac96b72afaffb489b.auiqqraehs.acm-validations.aws"
+    },
+    {
+      hostname = "_acme-challenge.channels.nixos.org"
+      type     = "CNAME"
+      value    = "9u55qij5w2odiwqxfi.fastly-validations.com"
+    },
+    {
+      hostname = "_acme-challenge.releases.nixos.org"
+      type     = "CNAME"
+      value    = "s731ezp9ameh5f349b.fastly-validations.com"
+    },
+    {
+      hostname = "_acme-challenge.tarballs.nixos.org"
+      type     = "CNAME"
+      value    = "vnqm62k5sjx9jogeqg.fastly-validations.com"
+    },
+    {
+      hostname = "cache.ngi0.nixos.org"
+      type     = "CNAME"
+      value    = "d2tu257wv37zz1.cloudfront.net"
+    },
+    {
+      hostname = "cache.nixos.org"
+      type     = "CNAME"
+      value    = "dualstack.v2.shared.global.fastly.net"
+    },
+    {
+      hostname = "channels.nixos.org"
+      type     = "CNAME"
+      value    = "dualstack.v2.shared.global.fastly.net"
+    },
+    {
+      hostname = "chat.nixos.org"
+      type     = "CNAME"
+      value    = "nixos.element.io."
+    },
+    {
+      hostname = "conf.nixos.org"
+      type     = "CNAME"
+      value    = "nixconberlin.github.io"
+    },
+    {
+      hostname = "discourse.nixos.org"
+      type     = "CNAME"
+      value    = "nixos1.hosted-by-discourse.com"
+    },
+    {
+      hostname = "mobile.nixos.org"
+      type     = "CNAME"
+      value    = "nixos.github.io"
+    },
+    {
+      hostname = "planet.nixos.org"
+      type     = "CNAME"
+      value    = "nixos-planet.netlify.com"
+    },
+    {
+      hostname = "releases.nixos.org"
+      type     = "CNAME"
+      value    = "dualstack.v2.shared.global.fastly.net"
+    },
+    {
+      hostname = "tarballs.nixos.org"
+      type     = "CNAME"
+      value    = "dualstack.v2.shared.global.fastly.net"
+    },
+    {
+      hostname = "weekly.nixos.org"
+      type     = "CNAME"
+      value    = "nixos-weekly.netlify.com"
+    },
   ]
 }
 

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,4 +1,10 @@
 # Our DNS is managed by Netlify
+#
+# NOTES on the provider:
+#
+# * NETLIFY and NETLIFY6 resource types are missing because no support
+# * The TTL is 3600 everywhere because the "ttl" attribute is not supported
+# * The MX records both have 10 priority because no support
 
 locals {
   # Shortcut to keep this a bit leaner
@@ -168,24 +174,6 @@ resource "netlify_dns_zone" "nixos" {
   name    = "nixos.org"
 }
 
-# Import fails on all types with:
-#
-#   Error: &{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
-#
-# resource "netlify_dns_record" "nixos" {
-#   zone_id  = local.zone_id
-#
-#   hostname = "nixos.org"
-#   type     = "NETLIFY"
-#   value    = "nixos-homepage.netlify.com"
-# }
-#
-# New entries can be created if they are not of NETLIFY type.
-#
-# TTL is not supported.
-
-# netlify api getDnsRecords -d '{ "zone_id": "5e6ce1b8b6f808aa16acd1ff" }'
-
 resource "netlify_dns_record" "nixos" {
   for_each = { for v in local.dns_records : "${v.hostname}-${v.type}" => v }
   zone_id  = local.zone_id
@@ -194,8 +182,9 @@ resource "netlify_dns_record" "nixos" {
   value    = each.value.value
 }
 
-# FIXME: both records have the same priority because the provider doesn't
-# support the "priority" argument.
+# MX records both have the same hostname and type and would clash on the above
+# mapping.
+
 resource "netlify_dns_record" "nixos_MX1" {
   zone_id  = local.zone_id
   hostname = "nixos.org"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,23 @@
+# Our DNS is managed by Netlify
+
+locals {
+  # Shortcut to keep this a bit leaner
+  zone_id = netlify_dns_zone.nixos.id
+}
+
+resource "netlify_dns_zone" "nixos" {
+  site_id = ""
+  name    = "nixos.org"
+}
+
+# Import fails with:
+#
+#   Error: &{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
+#
+# resource "netlify_dns_record" "test" {
+#   zone_id  = local.zone_id
+#
+#   hostname = "nixos.org"
+#   type     = "NETLIFY"
+#   value    = "nixos-homepage.netlify.com"
+# }

--- a/terraform/flake.lock
+++ b/terraform/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630322016,
-        "narHash": "sha256-dqKKXpxpdZp1fmyvxlN9ihM1cRjpj3S2Yjw8CvRz/uY=",
+        "lastModified": 1633342272,
+        "narHash": "sha256-81nIPU3IKq432OxpsLu2t1SoUmdNIvBloi1yF2aGNLc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc9e07ba1007b03d15427bac5275bea5b32f10ca",
+        "rev": "03754a32a00fcf325e3735240bcd28d4b6e44abc",
         "type": "github"
       },
       "original": {

--- a/terraform/flake.nix
+++ b/terraform/flake.nix
@@ -10,6 +10,8 @@
           (terraform.withPlugins (p: with p; [
             aws
             fastly
+            netlify
+            secret
           ]))
         ];
 

--- a/terraform/netlify_sites.tf
+++ b/terraform/netlify_sites.tf
@@ -1,0 +1,70 @@
+# This file contains all of the websites that we host using Netlify.
+
+resource "netlify_deploy_key" "key" {}
+
+resource "netlify_site" "nixos-summer" {
+  name          = "nixos-summer"
+  custom_domain = "summer.nixos.org"
+
+  repo {
+    provider    = "github"
+    repo_path   = "NixOS/nixos-summer"
+    repo_branch = "main"
+  }
+}
+
+resource "netlify_site" "nixos-common-styles" {
+  name          = "nixos-common-styles"
+  custom_domain = "common-styles.nixos.org"
+
+  repo {
+    provider    = "github"
+    repo_path   = "NixOS/nixos-common-styles"
+    repo_branch = "main"
+  }
+}
+
+resource "netlify_site" "nixos-status" {
+  name          = "nixos-status"
+  custom_domain = "status.nixos.org"
+
+  repo {
+    provider    = "github"
+    repo_path   = "NixOS/nixos-status"
+    repo_branch = "main"
+  }
+}
+
+resource "netlify_site" "nixos-planet" {
+  name          = "nixos-planet"
+  custom_domain = "planet.nixos.org"
+
+  repo {
+    provider    = "github"
+    repo_path   = "NixOS/nixos-planet"
+    repo_branch = "master"
+  }
+}
+
+resource "netlify_site" "nixos-search" {
+  name          = "nixos-search"
+  custom_domain = "search.nixos.org"
+
+  repo {
+    provider    = "github"
+    repo_path   = "NixOS/nixos-search"
+    repo_branch = "master"
+  }
+}
+
+resource "netlify_site" "nixos-homepage" {
+  name          = "nixos-homepage"
+  custom_domain = "nixos.org"
+
+  repo {
+    deploy_key_id = netlify_deploy_key.key.id
+    provider      = "github"
+    repo_path     = "NixOS/nixos-homepage"
+    repo_branch   = "master"
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -8,3 +8,13 @@ provider "aws" {
 }
 
 provider "fastly" {}
+
+# Create a token at https://app.netlify.com/user/applications/personal
+# And then import using `tf import secret_resource.netlify_token <TOKEN>`
+resource "secret_resource" "netlify_token" {
+  lifecycle { prevent_destroy = true }
+}
+
+provider "netlify" {
+  token = secret_resource.netlify_token.value
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -13,5 +13,11 @@ terraform {
     fastly = {
       source = "fastly/fastly"
     }
+    netlify = {
+      source = "AegirHealth/netlify"
+    }
+    secret = {
+      source = "nixpkgs/secret"
+    }
   }
 }


### PR DESCRIPTION
The goal of this PR is to import all of the Netlify resources into Terraform so their configuration is exposed to the community as a whole.

The Terraform provider DNS records are unfortunately not importable so I will have to delete them in the web UI, and hope that I didn't do copy-and-paste mistakes.

Backup of the DNS records in case I did some mistakes:
[dns-records-backup.json.gz](https://github.com/NixOS/nixos-org-configurations/files/7277785/dns-records-backup.json.gz)

TODO:
* [x] Apply A records
* [x] Add CNAME records
* [x] Add TXT records
* [x] Add MX records
* [ ] ~Add NETLIFY records~ (not supported by the provider)

Records removed:
* All the old ACM validation records.
* `*.conf.nixos.org` and `*.weekly.nixos.org` as they don't seem necessary.

/cc @NixOS/nixos-homepage . going forwards, please don't edit things manually in Netlify. I'm going to rotate the shared password to avoid that.

Fixes #163