### PR TITLE
macs/guest-catalina: configure zsh

### DIFF
--- a/macs/guest-catalina/darwin-configuration.nix
+++ b/macs/guest-catalina/darwin-configuration.nix
@@ -21,6 +21,8 @@ in
       config.nix.package
     ];
 
+  programs.zsh.enable = true;
+  programs.zsh.enableCompletion = false;
   programs.bash.enable = true;
   programs.bash.enableCompletion = false;
 


### PR DESCRIPTION
Otherwise, if an admin ever needs to SSH in and run Nix commands, they
won't be able to and will get "command not found" errors without
crafting a NIX_PATH and running the binary from the system profile.

---

cc @grahamc 