### PR TITLE
Add `variant`, `status` fields to channels.nix, export them in channel-exporter

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -1,87 +1,87 @@
 rec {
   channels = {
-      # "Channel name" = {
-      #   job = "project/jobset/jobname"; like https://hydra.nixos.org/job/<value>/latest-finished
-      #   # when adding a new version, mark the oldest as "not current". New releases should always be current.
-      #   # Channels where `current = false` are marked `end-of-life` on https://status.nixos.org/ and alerting is disabled.
-      #   current = true;
-      # };
-      "nixos-unstable" = {
-        job = "nixos/trunk-combined/tested";
-        current = true;
-      };
-      "nixos-unstable-small" = {
-        job = "nixos/unstable-small/tested";
-        current = true;
-      };
-      "nixpkgs-unstable" = {
-        job = "nixpkgs/trunk/unstable";
-        current = true;
-      };
-      
-      "nixos-21.11" = {
-        job = "nixos/release-21.11/tested";
-        current = true;
-      };
-      "nixos-21.11-small" = {
-        job = "nixos/release-21.11-small/tested";
-        current = true;
-      };
-      "nixpkgs-21.11-darwin" = {
-        job = "nixpkgs/nixpkgs-21.11-darwin/darwin-tested";
-        current = true;
-      };
-      "nixos-21.11-aarch64" = {
-        job = "nixos/release-21.11-aarch64/tested";
-        current = true;
-      };
+    # "Channel name" = {
+    #   job = "project/jobset/jobname"; like https://hydra.nixos.org/job/<value>/latest-finished
+    #   # when adding a new version, mark the oldest as "not current". New releases should always be current.
+    #   # Channels where `current = false` are marked `end-of-life` on https://status.nixos.org/ and alerting is disabled.
+    #   current = true;
+    # };
+    "nixos-unstable" = {
+      job = "nixos/trunk-combined/tested";
+      current = true;
+    };
+    "nixos-unstable-small" = {
+      job = "nixos/unstable-small/tested";
+      current = true;
+    };
+    "nixpkgs-unstable" = {
+      job = "nixpkgs/trunk/unstable";
+      current = true;
+    };
 
-      "nixos-21.05" = {
-        job = "nixos/release-21.05/tested";
-        current = true;
-      };
-      "nixos-21.05-small" = {
-        job = "nixos/release-21.05-small/tested";
-        current = true;
-      };
-      "nixpkgs-21.05-darwin" = {
-        job = "nixpkgs/nixpkgs-21.05-darwin/darwin-tested";
-        current = true;
-      };
-      "nixos-21.05-aarch64" = {
-        job = "nixos/release-21.05-aarch64/tested";
-        current = true;
-      };
+    "nixos-21.11" = {
+      job = "nixos/release-21.11/tested";
+      current = true;
+    };
+    "nixos-21.11-small" = {
+      job = "nixos/release-21.11-small/tested";
+      current = true;
+    };
+    "nixpkgs-21.11-darwin" = {
+      job = "nixpkgs/nixpkgs-21.11-darwin/darwin-tested";
+      current = true;
+    };
+    "nixos-21.11-aarch64" = {
+      job = "nixos/release-21.11-aarch64/tested";
+      current = true;
+    };
 
-      "nixos-20.09" = {
-        job = "nixos/release-20.09/tested";
-        current = false;
-      };
-      "nixos-20.09-small" = {
-        job = "nixos/release-20.09-small/tested";
-        current = false;
-      };
-      "nixpkgs-20.09-darwin" = {
-        job = "nixpkgs/nixpkgs-20.09-darwin/darwin-tested";
-        current = false;
-      };
-      "nixos-20.09-aarch64" = {
-        job = "nixos/release-20.09-aarch64/tested";
-        current = false;
-      };
+    "nixos-21.05" = {
+      job = "nixos/release-21.05/tested";
+      current = true;
+    };
+    "nixos-21.05-small" = {
+      job = "nixos/release-21.05-small/tested";
+      current = true;
+    };
+    "nixpkgs-21.05-darwin" = {
+      job = "nixpkgs/nixpkgs-21.05-darwin/darwin-tested";
+      current = true;
+    };
+    "nixos-21.05-aarch64" = {
+      job = "nixos/release-21.05-aarch64/tested";
+      current = true;
+    };
 
-      "nixos-20.03" = {
-        job = "nixos/release-20.03/tested";
-        current = false;
-      };
-      "nixos-20.03-small" = {
-        job = "nixos/release-20.03-small/tested";
-        current = false;
-      };
-      "nixpkgs-20.03-darwin" = {
-        job = "nixpkgs/nixpkgs-20.03-darwin/darwin-tested";
-        current = false;
-      };
+    "nixos-20.09" = {
+      job = "nixos/release-20.09/tested";
+      current = false;
+    };
+    "nixos-20.09-small" = {
+      job = "nixos/release-20.09-small/tested";
+      current = false;
+    };
+    "nixpkgs-20.09-darwin" = {
+      job = "nixpkgs/nixpkgs-20.09-darwin/darwin-tested";
+      current = false;
+    };
+    "nixos-20.09-aarch64" = {
+      job = "nixos/release-20.09-aarch64/tested";
+      current = false;
+    };
+
+    "nixos-20.03" = {
+      job = "nixos/release-20.03/tested";
+      current = false;
+    };
+    "nixos-20.03-small" = {
+      job = "nixos/release-20.03-small/tested";
+      current = false;
+    };
+    "nixpkgs-20.03-darwin" = {
+      job = "nixpkgs/nixpkgs-20.03-darwin/darwin-tested";
+      current = false;
+    };
   };
 
   channels-with-urls = (builtins.mapAttrs (name: about: about.job) channels);

--- a/channels.nix
+++ b/channels.nix
@@ -1,86 +1,121 @@
 rec {
   channels = {
     # "Channel name" = {
-    #   job = "project/jobset/jobname"; like https://hydra.nixos.org/job/<value>/latest-finished
-    #   # when adding a new version, mark the oldest as "not current". New releases should always be current.
-    #   # Channels where `current = false` are marked `end-of-life` on https://status.nixos.org/ and alerting is disabled.
-    #   current = true;
+    #   # This should be the <value> part of
+    #   # https://hydra.nixos.org/job/<value>/latest-finished
+    #   job = "project/jobset/jobname"; 
+    #
+    #   # When adding a new version, determine if it needs to be tagged as a
+    #   # variant -- for example:
+    #   # nixos-xx.xx         => primary
+    #   # nixos-xx.xx-small   => small
+    #   # nixos-xx.xx-darwin  => darwin
+    #   # nixos-xx.xx-aarch64 => aarch64
+    #   variant = "primary";
+    #
+    #   # Channel Status:
+    #   # '*-unstable' channels are always "rolling"
+    #   # Otherwise a release generally progresses through the following phases:
+    #   #
+    #   #  - Directly after branch off                   => "beta"
+    #   #  - Once the channel is released                => "stable"
+    #   #  - Once the next channel is released           => "deprecated"
+    #   #  - N months after the next channel is released => "unmaintained"
+    #   #    (check the release notes for when this should happen)
+    #   status = "beta";
     # };
     "nixos-unstable" = {
       job = "nixos/trunk-combined/tested";
-      current = true;
+      variant = "primary";
+      status = "rolling";
     };
     "nixos-unstable-small" = {
       job = "nixos/unstable-small/tested";
-      current = true;
+      variant = "small";
+      status = "rolling";
     };
     "nixpkgs-unstable" = {
       job = "nixpkgs/trunk/unstable";
-      current = true;
+      status = "rolling";
     };
 
     "nixos-21.11" = {
       job = "nixos/release-21.11/tested";
-      current = true;
+      variant = "primary";
+      status = "beta";
     };
     "nixos-21.11-small" = {
       job = "nixos/release-21.11-small/tested";
-      current = true;
+      variant = "small";
+      status = "beta";
     };
     "nixpkgs-21.11-darwin" = {
       job = "nixpkgs/nixpkgs-21.11-darwin/darwin-tested";
-      current = true;
+      variant = "darwin";
+      status = "beta";
     };
     "nixos-21.11-aarch64" = {
       job = "nixos/release-21.11-aarch64/tested";
-      current = true;
+      variant = "aarch64";
+      status = "beta";
     };
 
     "nixos-21.05" = {
       job = "nixos/release-21.05/tested";
-      current = true;
+      variant = "primary";
+      status = "stable";
     };
     "nixos-21.05-small" = {
       job = "nixos/release-21.05-small/tested";
-      current = true;
+      variant = "small";
+      status = "stable";
     };
     "nixpkgs-21.05-darwin" = {
       job = "nixpkgs/nixpkgs-21.05-darwin/darwin-tested";
-      current = true;
+      variant = "darwin";
+      status = "stable";
     };
     "nixos-21.05-aarch64" = {
       job = "nixos/release-21.05-aarch64/tested";
-      current = true;
+      variant = "aarch64";
+      status = "stable";
     };
 
     "nixos-20.09" = {
       job = "nixos/release-20.09/tested";
-      current = false;
+      variant = "primary";
+      status = "unmaintained";
     };
     "nixos-20.09-small" = {
       job = "nixos/release-20.09-small/tested";
-      current = false;
+      variant = "small";
+      status = "unmaintained";
     };
     "nixpkgs-20.09-darwin" = {
       job = "nixpkgs/nixpkgs-20.09-darwin/darwin-tested";
-      current = false;
+      variant = "darwin";
+      status = "unmaintained";
     };
     "nixos-20.09-aarch64" = {
       job = "nixos/release-20.09-aarch64/tested";
-      current = false;
+      variant = "aarch64";
+      status = "unmaintained";
     };
 
     "nixos-20.03" = {
       job = "nixos/release-20.03/tested";
-      current = false;
+      variant = "primary";
+      status = "unmaintained";
     };
     "nixos-20.03-small" = {
       job = "nixos/release-20.03-small/tested";
-      current = false;
+      variant = "small";
+      status = "unmaintained";
     };
     "nixpkgs-20.03-darwin" = {
       job = "nixpkgs/nixpkgs-20.03-darwin/darwin-tested";
-      current = false;
+      variant = "darwin";
+      status = "unmaintained";
     };
   };
 

--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -494,7 +494,7 @@ in {
         metrics_path = "/job/${value.job}/prometheus";
         static_configs = [ {
           labels = {
-            current = if value.current then "1" else "0";
+            current = if value.status != "unmaintained" then "1" else "0";
             channel = name;
           };
           targets = [ "hydra.nixos.org:443" ];

--- a/delft/eris/channel-exporter.py
+++ b/delft/eris/channel-exporter.py
@@ -13,7 +13,7 @@ import json
 CHANNEL_REVISION = Gauge(
     "channel_revision",
     "Current revision, exported as a hack",
-    ["channel", "revision"],
+    ["channel", "revision", "status", "variant", "current"],
 )
 
 
@@ -70,9 +70,12 @@ if __name__ == "__main__":
             measurement = measure_channel(channel)
             if measurement is not None:
                 revision = measurement['revision']
+                status = about.get('status', '')
+                variant = about.get('variant', '')
+                current = int(status != 'unmaintained')
                 CHANNEL_UPDATE_TIME.labels(channel=channel).set(measurement['timestamp'])
-                CHANNEL_REVISION.labels(channel=channel, revision=measurement['revision']).set(1)
-                CHANNEL_CURRENT.labels(channel=channel).set(int(about['current']))
+                CHANNEL_REVISION.labels(channel=channel, revision=revision, status=status, variant=variant, current=current).set(1)
+                CHANNEL_CURRENT.labels(channel=channel).set(current)
                 print('updated {}'.format(channel))
                 previous_revision = revisions.pop(channel, None)
                 revisions[channel] = revision


### PR DESCRIPTION
This can then be exported by prometheus in order to find the most recent
stable channel, as well as filter out variants such as small, aarch64,
and darwin channels.

---

Example query returning the latest stable NixOS version:

    channel_revision{current="1",stable="1",variant=""}

The variant is empty when there is no set variant because `nixos-21.05`
is not a variant but the "base", while `nixos-21.05-small` is a "small"
variant of `nixos-21.05`.