### PR TITLE
Revert "Reuse prometheus-exporters from nixpkgs"

### DIFF
--- a/delft/network.nix
+++ b/delft/network.nix
@@ -1,6 +1,10 @@
 flakes:
 
 let
+  networkoverlay = self: super: {
+    prometheus-postgres-exporter = self.callPackage ./prometheus/postgres-exporter.nix {};
+  };
+
   makeMac = { ip, extra }: {
     deployment = {
       targetHost = ip;
@@ -49,6 +53,7 @@ in {
           or (throw "Cannot deploy from an unclean source tree!");
         nixpkgs.overlays = [
           flakes.nix.overlay
+          networkoverlay
         ];
         nix.registry.nixpkgs.flake = flakes.nixpkgs;
         nix.nixPath = [ "nixpkgs=${flakes.nixpkgs}" ];

--- a/delft/prometheus/fastly.nix
+++ b/delft/prometheus/fastly.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+# Introduced in PR #133726 and should be removed when the network updates
+# to 21.11 or later.
+buildGoModule rec {
+  pname = "fastly-exporter";
+  version = "6.1.0";
+
+  src = fetchFromGitHub {
+    owner = "peterbourgon";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0my0pcxix5rk73m5ciz513nwmjcm7vjs6r8wg3vddm0xixv7zq94";
+  };
+
+  vendorSha256 = "1w9asky8h8l5gc0c6cv89m38qw50hyhma8qbsw3zirplhk9mb3r2";
+
+  meta = with lib; {
+    description = "Prometheus exporter for the Fastly Real-time Analytics API";
+    homepage = "https://github.com/peterbourgon/fastly-exporter";
+    license = licenses.asl20;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/delft/prometheus/packet-sd.nix
+++ b/delft/prometheus/packet-sd.nix
@@ -1,0 +1,23 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+buildGoModule rec {
+  pname = "prometheus-packet-sd";
+  version = "v0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "packethost";
+    repo = "prometheus-packet-sd";
+    rev = "v0.0.3";
+    sha256 = "sha256-2k8AsmyhQNNZCzpVt6JdgvI8IFb5pRi4ic6Yn2NqHMM=";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Prometheus service discovery for Packet.";
+    homepage = "https://github.com/packethost/prometheus-packet-sd";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/delft/prometheus/postgres-exporter.nix
+++ b/delft/prometheus/postgres-exporter.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
+
+buildGoModule rec {
+  pname = "postgres_exporter";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "wrouesnel";
+    repo = "postgres_exporter";
+    rev = "v${version}";
+    sha256 = "sha256-Kv+sjqhlmH36L4YvDuGYODR/eTHA2TKQ6IUCXAiItyo=";
+  };
+
+  vendorSha256 = "sha256-yMcoUl9NsiiZQyEHlLu79DzIyl6BbhLZ/xNFavaGrEs=";
+
+  doCheck = true;
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) postgres; };
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "A Prometheus exporter for PostgreSQL";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fpletz globin willibutz ma27 ];
+  };
+}


### PR DESCRIPTION
Reverts NixOS/nixos-org-configurations#195

```
error: attribute 'fastly-exporter' missing

       at /nix/store/33zzxrj3kzlyv22qm3p7a703dp69cshd-source/nixos/modules/services/monitoring/prometheus/exporters/fastly.nix:35:9:

           34|       "export FASTLY_API_TOKEN=$(cat ${toString cfg.tokenPath})"}
           35|       ${pkgs.fastly-exporter}/bin/fastly-exporter \
             |         ^
           36|         -endpoint http://${cfg.listenAddress}:${cfg.port}/metrics
```

which I fixed with:

```
--- a/delft/network.nix
+++ b/delft/network.nix
@@ -49,6 +49,9 @@ in {
           or (throw "Cannot deploy from an unclean source tree!");
         nixpkgs.overlays = [
           flakes.nix.overlay
+          (final: prev: {
+            fastly-exporter = final.prometheus-fastly-exporter;
+          })
         ];
```

which then revealed:

```
error: cannot coerce an integer to a string

       at /nix/store/33zzxrj3kzlyv22qm3p7a703dp69cshd-source/nixos/modules/services/monitoring/prometheus/exporters/fastly.nix:36:47:

           35|       ${pkgs.fastly-exporter}/bin/fastly-exporter \
           36|         -endpoint http://${cfg.listenAddress}:${cfg.port}/metrics
             |                                               ^
           37|         ${optionalString cfg.debug "-debug true"} \
(use '--show-trace' to show detailed location information)
```

so now I'm reverting until I can test and PR a proper fix to the fastly exporter.