### PR TITLE
channels: add nixos-21.11-x86_64

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -3,7 +3,7 @@ rec {
     # "Channel name" = {
     #   # This should be the <value> part of
     #   # https://hydra.nixos.org/job/<value>/latest-finished
-    #   job = "project/jobset/jobname"; 
+    #   job = "project/jobset/jobname";
     #
     #   # When adding a new version, determine if it needs to be tagged as a
     #   # variant -- for example:
@@ -57,6 +57,11 @@ rec {
     "nixos-21.11-aarch64" = {
       job = "nixos/release-21.11-aarch64/tested";
       variant = "aarch64";
+      status = "stable";
+    };
+    "nixos-21.11-x86_64" = {
+      job = "nixos/release-21.11-x86_64/tested";
+      variant = "x86_64";
       status = "stable";
     };
 


### PR DESCRIPTION
Add the x86_64 channel complementary to aarch64.

While the aggregate channel is important to keep heterogeneous system
landscapes in sync, there is still a substantial user base that only
cares about x86_64.

However, the aggregate channel is often blocked from advancing by build/test
failures that only affect aarch64. As x86_64 is a tier 1 platform (as per RFC0046),
it deserves a dedicated channel.

The impact on Hydra should be negligible, due to caching and no new build artefacts
being introduced.

There has been also been some discussion around this, e.g. in https://github.com/NixOS/nixpkgs/issues/150532
and occasionally on Discourse and so far no one opposed to creating this channel.