### PR TITLE
terraform/cache.tf: add CORS to response instead of cache

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -175,7 +175,7 @@ resource "fastly_service_v1" "cache" {
   # Allow CORS GET requests.
   header {
     destination = "http.access-control-allow-origin"
-    type        = "cache"
+    type        = "response"
     action      = "set"
     name        = "CORS Allow"
     source      = "\"*\""


### PR DESCRIPTION
Because 404s are synthesized, these are cached somewhere after the cached-response headers are set, overriding the CORS header set on all responses. This means that, while any 200 can be read by a CORS-abiding HTTP client, 404s get `NetworkError`s.

I'm a little uncertain if this will entirely fix it, since it depends on the order that Fastly generates their VCL components in. (I believe the way synthetic responses are generated are by restarting, so that might cause the headers to not be stored, making this a simple fix.) I could not find a way to generate fastly's VCL, though, so no guarantees on correctness. 