### PR TITLE
delft/eris: add alert for missing builder types

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -130,6 +130,17 @@ in {
               annotations.summary = "{{ $labels.machine }} has {{ $value }} over-age jobs.";
               annotations.grafana = "https://monitoring.nixos.org/grafana/d/j0hJAY1Wk/in-progress-build-duration-heatmap";
             }
+
+            {
+              alert = "BuilderTypeMissing";
+              expr = ''
+                hydra_machine_type_runnable > 0 and hydra_machine_type_running == 0 and (hydra_machine_type_last_active_total < time() - 60)
+              '';
+              for = "30m";
+              labels.severity = "warning";
+              annotations.summary = "Runnable jobs for {{ $labels.machineType }}, but no runners to execute.";
+              annotations.summary = "https://monitoring.nixos.org/grafana/d/MJw9PcAiz/hydra-jobs?orgId=1&from=now-7d&to=now&refresh=5m&var-machine=All&viewPanel=2";
+            }
           ];
         }
 


### PR DESCRIPTION
We currently have no runners to service aarch64-linux:big-parallel jobs, this rule detects these situations.

https://monitoring.nixos.org/prometheus/graph?g0.expr=hydra_machine_type_runnable%20%3E%200%20and%20hydra_machine_type_running%20%3D%3D%200%20and%20(hydra_machine_type_last_active_total%20%3C%20time()%20-%203600)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1w