### PR TITLE
delft/eris: Increase lookback window in BuilderTypeMissing

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -134,9 +134,8 @@ in {
             {
               alert = "BuilderTypeMissing";
               expr = ''
-                hydra_machine_type_runnable > 0 and hydra_machine_type_running == 0 and (hydra_machine_type_last_active_total < time() - 60)
+                hydra_machine_type_runnable > 0 and hydra_machine_type_running == 0 and (hydra_machine_type_last_active_total < time() - (2*86400))
               '';
-              for = "30m";
               labels.severity = "warning";
               annotations.summary = "Runnable jobs for {{ $labels.machineType }}, but no runners to execute.";
               annotations.grafana = "https://monitoring.nixos.org/grafana/d/MJw9PcAiz/hydra-jobs?orgId=1&from=now-7d&to=now&refresh=5m&var-machine=All&viewPanel=2";


### PR DESCRIPTION
This cuts down alerts to scenarios that aren't caused by scheduling
alone. A builder type should see some usage in a two day window.