### PR TITLE
hydra: increase max_output_size from 2GB to 3GB

### DIFF
--- a/delft/hydra.nix
+++ b/delft/hydra.nix
@@ -56,6 +56,8 @@ in
       max_unsupported_time = 86400
 
       allow_import_from_derivation = false
+      
+      max_output_size = 3221225472 # 3 << 30 = 3 GB
 
       <hydra_notify>
         <prometheus>


### PR DESCRIPTION
A potential solution for https://github.com/NixOS/nixpkgs/issues/159612

Currently the Hydra nixos-unstable channel is clogged due to the Gnome ISO being just a tad bit bigger than 2GB. This results in the ISO build itself succeeding, but hydra marking the build as failing because of a failing validation check for the size. This has been the case for 6 days now. I'm suggesting this PR as a short-term solution. There are some critical CVE's that were fixed, but are not coming through right now (https://github.com/NixOS/nixpkgs/pull/160354).

The validation check for the output size seems to be here: https://github.com/NixOS/hydra/blob/f6e86efc9fc4f132cc183bc1c139fbaeeaa19238/src/hydra-queue-runner/build-remote.cc#L472-L475

`maxOutputSize` is initialized with configuration option `max_output_size` here: https://github.com/NixOS/hydra/blob/d0bc0d0edafef4201a33391eae243c0e3c6925d3/src/hydra-queue-runner/hydra-queue-runner.cc#L44. Note that its default is `2 << 30`, thus 2GB.

Note that I don't run Hydra myself and have never done anything with nixos-org-configurations before, so this is a bit of a 'change in the dark' for me. I wanted to propose this as a short-term (temporary?) solution until the discussions and long-term solutions in https://github.com/NixOS/nixpkgs/issues/159612 have been concluded

Feel free to edit this PR/commit if needed.