### PR TITLE
Add live.nixos.org DNS entry

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -188,8 +188,18 @@ locals {
     },
     {
       hostname = "live.nixos.org"
+      type     = "TXT"
+      value    = "machine-owner=@bryanhonof provider=hetzner-cloud service=owncloud"
+    },
+    {
+      hostname = "live.nixos.org"
       type     = "A"
       value    = "167.235.51.204"
+    },
+    {
+      hostname = "live.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:c0c:96cc::42"
     },
   ]
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -189,7 +189,7 @@ locals {
     {
       hostname = "live.nixos.org"
       type     = "TXT"
-      value    = "machine-owner=@bryanhonof provider=hetzner-cloud service=owncloud"
+      value    = "machine-owner=@bryanhonof provider=hetzner-cloud service=owncast"
     },
     {
       hostname = "live.nixos.org"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -186,6 +186,11 @@ locals {
       type     = "TXT"
       value    = "v=spf1 include:spf.improvmx.com ~all"
     },
+    {
+      hostname = "live.nixos.org"
+      type     = "A"
+      value    = "167.235.51.204"
+    },
   ]
 }
 


### PR DESCRIPTION
For the Summer of Nix Lecture Series we set up an Owncast instance,
currently running under live.bjth.xyz. I'd be better marketing if we ran
that under live.nixos.org instead :).