### PR TITLE
eris / channel-exporter: add back the time.sleep to keep from hitting…

### DIFF
--- a/delft/eris/channel-exporter.py
+++ b/delft/eris/channel-exporter.py
@@ -81,3 +81,4 @@ if __name__ == "__main__":
                 revisions[channel] = revision
                 if previous_revision and previous_revision != revision:
                     CHANNEL_REVISION.remove(channel, previous_revision, status, variant, current)
+        time.sleep(55)


### PR DESCRIPTION
… the releases files millions of times a day.

This got lost a couple years ago by mistake: https://github.com/NixOS/nixos-org-configurations/commit/d2ce99be395b19ba4cc8695b227cb03dc325fd77