### PR TITLE
Add terraform lock file from bastion

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,30 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/aegirhealth/netlify" {
+  version = "0.6.12"
+  hashes = [
+    "h1:8WjKJ00XZHZ8WEWBPohsmyg9XyOBnLC5CVcrm/dBXdM=",
+  ]
+}
+
+provider "registry.terraform.io/fastly/fastly" {
+  version = "0.34.0"
+  hashes = [
+    "h1:1ewjh2aw/lOZqFPqS1ZdeNjxfwtZU0D2rcVhPEEGx9w=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.56.0"
+  hashes = [
+    "h1:qGsDRNQ5ggUIxbhDB1ti5MAe5coP3WyoEX2wAY89qD0=",
+  ]
+}
+
+provider "registry.terraform.io/nixpkgs/secret" {
+  version = "1.1.1"
+  hashes = [
+    "h1:Jwt07VaMlSukMitRRskKZ1NXnv+UxipSSPHRgnP57SQ=",
+  ]
+}


### PR DESCRIPTION
Without this, `terraform init` fails with:
```
╷
│ Error: Failed to install provider
│ 
│ Error while installing hashicorp/aws v3.56.0: the local package for registry.terraform.io/hashicorp/aws 3.56.0 doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for
│ packages targeting different platforms)
╵

╷
│ Error: Failed to install provider
│ 
│ Error while installing fastly/fastly v0.34.0: the local package for registry.terraform.io/fastly/fastly 0.34.0 doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for
│ packages targeting different platforms)
╵
```