### PR TITLE
channels: Add NixOS 22.11 as beta

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -39,6 +39,22 @@ rec {
       status = "rolling";
     };
 
+    "nixos-22.11" = {
+      job = "nixos/release-22.11/tested";
+      variant = "primary";
+      status = "beta";
+    };
+    "nixos-22.11-small" = {
+      job = "nixos/release-22.11-small/tested";
+      variant = "small";
+      status = "beta";
+    };
+    "nixpkgs-22.11-darwin" = {
+      job = "nixpkgs/nixpkgs-22.11-darwin/darwin-tested";
+      variant = "darwin";
+      status = "beta";
+    };
+
     "nixos-22.05" = {
       job = "nixos/release-22.05/tested";
       variant = "primary";


### PR DESCRIPTION
With the branch-off tomorrow the jobsets will come into existance and the channels should follow soon after.