### PR TITLE
enable TLS redirect for hydra.nixos.org

### DIFF
--- a/delft/hydra-proxy.nix
+++ b/delft/hydra-proxy.nix
@@ -46,7 +46,7 @@ in
       '';
 
     virtualHosts."hydra.nixos.org" =
-      { addSSL = true;
+      { forceSSL = true;
         enableACME = true;
         extraConfig = ''
           # Required by Catalyst.


### PR DESCRIPTION
In 2022 one should not accidentally be on a non-TLS website when just entering "hydra.nixos.org" in the url bar