### PR TITLE
Introduce reproducible.nixos.org

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -72,6 +72,11 @@ locals {
       value    = "2a01:4f8:c0c:6e2c::1"
     },
     {
+      hostname = "reproducible.nixos.org"
+      type     = "CNAME"
+      value    = "nixos.github.io"
+    },
+    {
       hostname = "_293364b7f7ebb076ac287cd132f8b316.cache.ngi0.nixos.org"
       type     = "CNAME"
       value    = "_6a75cfb0c20f4eaac96b72afaffb489b.auiqqraehs.acm-validations.aws"


### PR DESCRIPTION
It would be good to have a place to collect information about Reproducible Builds on Nix. Currently there is https://r13y.com, but it is rather outdated and it would be good to gradually move this to more shared infrastructure so we can collaborate on maintaining it.

This is a first step in that direction, having more up-to-date reports hosted from my uberspace.de account. Next steps might be to generate those reports from nix-community infra and host them on the Nix netlify, but let's take one step at a time.

You can preview the content at https://nix-rb.bzzt.net