### PR TITLE
macs/flake.lock: Update

### DIFF
--- a/macs/flake.lock
+++ b/macs/flake.lock
@@ -21,10 +21,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666753130,
+        "lastModified": 1675758091,
+        "narHash": "sha256-7gFSQbSVAFUHtGCNHPF7mPc5CcqDk9M2+inlVPZSneg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
+        "rev": "747927516efcb5e31ba03b7ff32f61f6d47e7d87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f540aeda6f677354f1e7144ab04352f61aaa0118' (2022-10-26)
  → 'github:nixos/nixpkgs/747927516efcb5e31ba03b7ff32f61f6d47e7d87' (2023-02-07)

---

Most importantly, updates macs relying on this config to nix 2.13.2, which includes a fix for the auto-gc issue that sometimes crops up: https://github.com/NixOS/nix/pull/7542