### PR TITLE
Add live.nixos.org records

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -192,6 +192,21 @@ locals {
       value    = "v=spf1 include:spf.improvmx.com ~all"
     },
     {
+      hostname = "live.nixos.org"
+      type     = "TXT"
+      value    = "machine-owner=@bryanhonof provider=hetzner-cloud service=owncast"
+    },
+    {
+      hostname = "live.nixos.org"
+      type     = "A"
+      value    = "135.181.145.218"
+    },
+    {
+      hostname = "live.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f9:c011:bca2::/64"
+    },
+    {
       # hetzner m1 1638981
       hostname = "intense-heron.mac.nixos.org"
       type     = "A"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -204,7 +204,7 @@ locals {
     {
       hostname = "live.nixos.org"
       type     = "AAAA"
-      value    = "2a01:4f9:c011:bca2::/64"
+      value    = "2a01:4f9:c011:bca2::"
     },
     {
       # hetzner m1 1638981


### PR DESCRIPTION
For Nix's 20th anniversary, the marketing team had the idea to host livestreams like during the Summer of Nix. I've just re-used the server config of the Summer of Nix, but these records were removed back then.

cc: @zimbatm @garbas 