### PR TITLE
Pin Nix to 2.13 for Mac builders

### DIFF
--- a/macs/flake.lock
+++ b/macs/flake.lock
@@ -21,11 +21,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675758091,
-        "narHash": "sha256-7gFSQbSVAFUHtGCNHPF7mPc5CcqDk9M2+inlVPZSneg=",
+        "lastModified": 1677852945,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "747927516efcb5e31ba03b7ff32f61f6d47e7d87",
+        "rev": "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb",
+        "treeHash": "ed9cb4b940416524f6f6dd655004284dc1a80bd8",
         "type": "github"
       },
       "original": {

--- a/macs/nix-darwin.nix
+++ b/macs/nix-darwin.nix
@@ -32,6 +32,7 @@ in
 
   services.nix-daemon.enable = true;
 
+  nix.package = pkgs.nixVersions.nix_2_13;
   nix.settings = {
     "extra-experimental-features" = [ "nix-command" "flakes" ];
     max-jobs = 4;


### PR DESCRIPTION
Supercedes https://github.com/NixOS/nixos-org-configurations/pull/239.