### PR TITLE
non-critical-infra: add first-time-contribution-tagger

### DIFF
--- a/non-critical-infra/.sops.yaml
+++ b/non-critical-infra/.sops.yaml
@@ -1,0 +1,14 @@
+keys: 
+  - &hexa age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x
+  - &julienmalka age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976
+  - &zimbatm age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h
+  - &hetzner01 age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq
+creation_rules:
+  - path_regex: secrets/[^/]+.hetzner01
+    key_groups:
+    - age:
+      - *hexa
+      - *julienmalka
+      - *zimbatm
+      - *hetzner01
+

--- a/non-critical-infra/flake.lock
+++ b/non-critical-infra/flake.lock
@@ -219,6 +219,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1692492726,
+        "narHash": "sha256-rld5qm2B4oRkDwcPD+yOSyTrZQdfCR6mzJGGkecjvTs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5e63e8bbc46bc4fc22254da1edaf42fc7549c18a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1689168768,
@@ -346,7 +362,29 @@
         "first-time-contribution-tagger": "first-time-contribution-tagger",
         "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs_5",
+        "sops-nix": "sops-nix",
         "srvos": "srvos"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1692728678,
+        "narHash": "sha256-02MjG7Sb9k7eOi86CcC4GNWVOjT6gjmXFSqkRjZ8Xyk=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "1b7b3a32d65dbcd69c217d7735fdf0a6b2184f45",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "srvos": {

--- a/non-critical-infra/flake.lock
+++ b/non-critical-infra/flake.lock
@@ -39,6 +39,31 @@
         "type": "github"
       }
     },
+    "first-time-contribution-tagger": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1686955840,
+        "narHash": "sha256-8g33tg+D0wJWFYQH4GJtX77BOdK+x1F90nw9m7ux+zM=",
+        "owner": "Janik-Haag",
+        "repo": "first-time-contribution-tagger",
+        "rev": "f8e4eb2780f94977671ec68a70d1baa3bae63216",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Janik-Haag",
+        "repo": "first-time-contribution-tagger",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -47,6 +72,22 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -75,6 +116,42 @@
         "systems": "systems"
       },
       "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
         "lastModified": 1689068808,
         "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
@@ -85,6 +162,28 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "first-time-contribution-tagger",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -100,6 +199,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -122,6 +237,37 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1686955712,
+        "narHash": "sha256-VDJSytcXtyXY74R3v/asQENBGx9/WtUFF/MhBzJPGLM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0bb464b79bafd0963faafffb9c21a6a8b405bc6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1685866647,
+        "narHash": "sha256-4jKguNHY/edLYImB+uL8jKPL/vpfOvMmSlLAGfxSrnY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a53a3bec10deef6e1cc1caba5bc60f53b959b1e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
         "lastModified": 1690726002,
         "narHash": "sha256-cACz6jCJZtsZHGCJAN4vMobxzH5s6FCOTZHMrh/Hu0M=",
         "owner": "NixOS",
@@ -136,7 +282,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1690327932,
         "narHash": "sha256-Fv7PYZxN4eo0K6zXhHG/vOc+e2iuqQ5ywDrh0yeRjP0=",
@@ -152,18 +298,60 @@
         "type": "github"
       }
     },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1686707892,
+        "narHash": "sha256-j6a1v3VLcGSBITwsmUsXbDnV2dXG66fD7kUlRK0sVT4=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "71813779d4cef5fe2ba7de3d6a86f802e9230dd8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1686668298,
+        "narHash": "sha256-AADh9NqHh6X2LOem4BvI7oCkMm+JPCSCE7iIw5nn0VA=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5b6b54d3f722aa95cbf4ddbe35390a0af8c0015a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "colmena": "colmena",
         "disko": "disko",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3",
+        "first-time-contribution-tagger": "first-time-contribution-tagger",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_5",
         "srvos": "srvos"
       }
     },
     "srvos": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1691135985,
@@ -196,6 +384,36 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/non-critical-infra/flake.nix
+++ b/non-critical-infra/flake.nix
@@ -7,6 +7,10 @@
     flake-utils.url = "github:numtide/flake-utils";
     disko.url = "github:nix-community/disko";
     srvos.url = "github:numtide/srvos";
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     first-time-contribution-tagger = {
       url = "github:Janik-Haag/first-time-contribution-tagger";
@@ -17,7 +21,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, colmena, disko, srvos, first-time-contribution-tagger, ... }@inputs:
+  outputs = { self, nixpkgs, flake-utils, colmena, disko, srvos, first-time-contribution-tagger, sops-nix, ... }@inputs:
     let
       importConfig = path: (lib.mapAttrs (name: value: import (path + "/${name}/default.nix")) (lib.filterAttrs (_: v: v == "directory") (builtins.readDir path)));
       lib = nixpkgs.lib;
@@ -31,7 +35,7 @@
           specialArgs = {
             inherit inputs;
           };
-          modules = [ value disko.nixosModules.disko first-time-contribution-tagger.nixosModule ];
+          modules = [ value disko.nixosModules.disko first-time-contribution-tagger.nixosModule sops-nix.nixosModules.sops ];
           extraModules = [ inputs.colmena.nixosModules.deploymentOptions ];
 
         })
@@ -56,8 +60,9 @@
       in {
         devShell =
           pkgs.mkShell {
-            buildInputs = [
+            buildInputs = with pkgs; [
               colmena.packages.${system}.colmena
+              sops
             ];
           };
       });

--- a/non-critical-infra/flake.nix
+++ b/non-critical-infra/flake.nix
@@ -7,9 +7,17 @@
     flake-utils.url = "github:numtide/flake-utils";
     disko.url = "github:nix-community/disko";
     srvos.url = "github:numtide/srvos";
+
+    first-time-contribution-tagger = {
+      url = "github:Janik-Haag/first-time-contribution-tagger";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, colmena, disko, srvos, ... }@inputs:
+  outputs = { self, nixpkgs, flake-utils, colmena, disko, srvos, first-time-contribution-tagger, ... }@inputs:
     let
       importConfig = path: (lib.mapAttrs (name: value: import (path + "/${name}/default.nix")) (lib.filterAttrs (_: v: v == "directory") (builtins.readDir path)));
       lib = nixpkgs.lib;
@@ -23,7 +31,7 @@
           specialArgs = {
             inherit inputs;
           };
-          modules = [ value disko.nixosModules.disko ];
+          modules = [ value disko.nixosModules.disko first-time-contribution-tagger.nixosModule ];
           extraModules = [ inputs.colmena.nixosModules.deploymentOptions ];
 
         })

--- a/non-critical-infra/hosts/hetzner-01/default.nix
+++ b/non-critical-infra/hosts/hetzner-01/default.nix
@@ -6,6 +6,7 @@
       ./hardware.nix
       inputs.srvos.nixosModules.server
       inputs.srvos.nixosModules.hardware-hetzner-online-amd
+      ../../modules/first-time-contribution-tagger.nix
     ];
 
 

--- a/non-critical-infra/modules/first-time-contribution-tagger.nix
+++ b/non-critical-infra/modules/first-time-contribution-tagger.nix
@@ -1,0 +1,13 @@
+{
+  services.first-time-contribution-tagger = {
+    enable = true;
+    interval = "*:0/10";
+    environment = {
+      FIRST_TIME_CONTRIBUTION_LABEL="12. first-time contribution";
+      FIRST_TIME_CONTRIBUTION_CACHE="/var/lib/first-time-contribution-tagger/cache";
+      FIRST_TIME_CONTRIBUTION_REPO="nixpkgs";
+      FIRST_TIME_CONTRIBUTION_ORG="NixOS";
+    };
+    environmentFile = "/root/first-time-contribution-tagger.env";
+  };
+}

--- a/non-critical-infra/modules/first-time-contribution-tagger.nix
+++ b/non-critical-infra/modules/first-time-contribution-tagger.nix
@@ -3,11 +3,17 @@
     enable = true;
     interval = "*:0/10";
     environment = {
-      FIRST_TIME_CONTRIBUTION_LABEL="12. first-time contribution";
-      FIRST_TIME_CONTRIBUTION_CACHE="/var/lib/first-time-contribution-tagger/cache";
-      FIRST_TIME_CONTRIBUTION_REPO="nixpkgs";
-      FIRST_TIME_CONTRIBUTION_ORG="NixOS";
+      FIRST_TIME_CONTRIBUTION_LABEL = "12. first-time contribution";
+      FIRST_TIME_CONTRIBUTION_CACHE = "/var/lib/first-time-contribution-tagger/cache";
+      FIRST_TIME_CONTRIBUTION_REPO = "nixpkgs";
+      FIRST_TIME_CONTRIBUTION_ORG = "NixOS";
     };
     environmentFile = "/root/first-time-contribution-tagger.env";
+  };
+
+  sops.secrets.first-time-contribution-tagger-env = {
+    sopsFile = ../secrets/first-time-contribution-tagger-env.hetzner01;
+    format = "binary";
+    path = "/root/first-time-contribution-tagger.env";
   };
 }

--- a/non-critical-infra/secrets/first-time-contribution-tagger-env.hetzner01
+++ b/non-critical-infra/secrets/first-time-contribution-tagger-env.hetzner01
@@ -1,0 +1,32 @@
+{
+	"data": "ENC[AES256_GCM,data:QfZKMt/EfEx/EYUbizZCkNyPWyyBzx3tBfG/BdQdUSoIUgjBGJSXRZQrXIaiczaPTRK4BoHjLGBo+5gY3jTffmoyrZ1JMYLe4ZHVTnpLXyk=,iv:varEp8M6uS8Kw8P8Ou9M7TDS+ycMjMqCOUFQ1XWnqKM=,tag:q8NH8BKm2ZpxciBJ+sFzfQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDY1lGRzVmajJuMFZPdGM2\nYnljMkwvNTZ4cTlvTzBZK3h5QUVqVHFwOEFVCjR5U003ZVZ3Rld2Y1VvWVJYOXNS\nTTZ6N2hkRGlNYTdYa0hQYU85dnVidU0KLS0tIGtaZ2RhNmVGV1VxZ0Zobkw2QjFY\nMXRteWE2cWw5anZWeGtqZEYyeTZHTDAKX5ybCiVckAldRZ4lZrYcU2c3Gt1/UUOp\np4VgzQyNbuFkyQSpWkl4jEpOO590PvYE1D50EQ69pouVj1y/UBlDtA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3aFhlZWcxWlpQMjloT3VQ\nS09yMlhkZVR2a0xDZTBORmlxdFVTRWN2M0dRCmtBcnA1NW5CL003d0RWZWRKQ1Bp\nL2hJTmNwREtlNTBENEpmeENOYU1PS3MKLS0tIGNWUFB1WGFnZFFkNGtiei8xNFpm\neDJadEdMUGgxd21pc29xamR6TVJUVHcKNqxzHPv9C8O6T49UQg1yqXjad2wRanS6\nNlgxR/yREQYiYCJuA8juqPsQJruNHrM+SCSHRUsaYcbH2+GjVkQncw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMSUt6bW81aGxwSTh6RDIv\nZHBQTURnU3BLSzltN2Y0TWdHZFcrdmF2V1U4Cm9FUzZpb25RS2QvVExwMFFqdHZL\nZStBOWN4dnAvWWN6UXMvdHduSlF5U1UKLS0tIFlKUGFQZkxpdGxOMGRXUXIvZWNq\nSWV0UEQ0QlZUWEtDaDFMZE5qVlo2WEUKid1Q5gQVrczlkinUmF2/xT4yxt1z/p6c\n4tLRxCCl1IO3bZ+ci9LWRZQung+Mwj4bQE9i5mf8yZqKGSs26z0DTw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrRkxPcVRMUFkvclZDVEVE\nT1pJdWxROVRpTVRzOWQzZkZ1OXdiajJidWdNCm9qemJHSGlUTXA0aVo0eFM0MGJi\nTDEzek1YbThNcGFOcFpEL2l0bWpySkkKLS0tIFgvSXlicldVZTdhTTVUQU5qZ29Q\nNTY5bloweUYxUzc5NVVGWTdMdzZ6UGMKghtaC7SHai0ilVnO87OwC3vlI97U5s3t\n18gr9qHETPFDkj83X5IBpneYC84rHI5D1OVpEDNUg/sGbgXgzcjzTw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2023-08-23T14:49:15Z",
+		"mac": "ENC[AES256_GCM,data:xjbHz6Lbf0H9r8Lx3v2DNoEa44ZpEDe2gbHxQiB0iDct1EROr1dt99V7sN6oc2KyuSSHYTJCNvgTimWVRgmTKF7S+bhgrMY5I/4TLqcv5zpq0NcbWB4BePj8W73sBVQEKRKt9giHLSDyb1KJ5/ywMpF2ZF7D6wz7BB2Qiqovz08=,iv:oS3tumdSKWCmwkWunwY5HHC92LlU6Z9YkDjIqcCWCYI=,tag:chkpbOLnx4JT9PkuAYbhCA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}


### PR DESCRIPTION
There is still some stuff to do like adding secret management with something like sops or agenix
I have to push version 1.0.0 of the first-time-contribution-tagger which will add a configuration option to download the cache from the GitHub release so there won't be any imperative steps left for setting this up.
The repo at github.com/janik-Haag/first-time-contribution-tagger will probably be moved to the nix-community name space. 

I also obviously can't test if this deploys fine to the hetzner machine. 
This closes #258