### PR TITLE
Move releases to Infrequent Access after a year

### DIFF
--- a/terraform/releases.tf
+++ b/terraform/releases.tf
@@ -13,6 +13,15 @@ locals {
 resource "aws_s3_bucket" "releases" {
   bucket = "nix-releases"
 
+  lifecycle_rule {
+    enabled = true
+
+    transition {
+      days          = 365
+      storage_class = "STANDARD_IA"
+    }
+  }
+
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["HEAD", "GET"]


### PR DESCRIPTION
Since we have 28 TB in this bucket, this gives a non-trivial savings.