### PR TITLE
Reuse ssh-keys for non-critical-infra

### DIFF
--- a/non-critical-infra/hosts/hetzner-01/default.nix
+++ b/non-critical-infra/hosts/hetzner-01/default.nix
@@ -44,20 +44,15 @@
 
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:5a:186c::2";
 
-  users.users.root.openssh.authorizedKeys.keyFiles = [
-    (pkgs.fetchurl {
-      url = "https://github.com/JulienMalka.keys";
-      sha256 = "sha256-yH84N5aPt9MJDuvaDf9BvnM+z9yaUKYxU7W2Bf89174=";
-    })
-    (pkgs.fetchurl {
-      url = "https://github.com/zimbatm.keys";
-      sha256 = "sha256-QEOYK1aoF626VTTjlcFtY020NSCfiCnBRQfrNfl0j5s=";
-    })
-    (pkgs.fetchurl {
-      url = "https://github.com/mweinelt.keys";
-      sha256 = "sha256-gAD2jUc5SBWuuiRGgJEmb0I7rR/jti1FMxVuA0BtILk=";
-    })
-  ];
+  users.users.root.openssh.authorizedKeys = {
+    keyFiles = [
+      (pkgs.fetchurl {
+        url = "https://github.com/JulienMalka.keys";
+        hash = "sha256-glt0tL13aqC00/Bu+13xZbOGqeNlYx5oElLwfYs7knY=";
+      })
+    ];
+    keys = (import ../../../ssh-keys.nix).infra;
+  };
 
   system.stateVersion = "23.05";
 

--- a/non-critical-infra/hosts/hetzner-01/default.nix
+++ b/non-critical-infra/hosts/hetzner-01/default.nix
@@ -44,15 +44,7 @@
 
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:5a:186c::2";
 
-  users.users.root.openssh.authorizedKeys = {
-    keyFiles = [
-      (pkgs.fetchurl {
-        url = "https://github.com/JulienMalka.keys";
-        hash = "sha256-glt0tL13aqC00/Bu+13xZbOGqeNlYx5oElLwfYs7knY=";
-      })
-    ];
-    keys = (import ../../../ssh-keys.nix).infra;
-  };
+  users.users.root.openssh.authorizedKeys.keys = (import ../../../ssh-keys.nix).infra;
 
   system.stateVersion = "23.05";
 

--- a/ssh-keys.nix
+++ b/ssh-keys.nix
@@ -26,4 +26,8 @@ rec {
   hexa-helix = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFSpdtIxIBFtd7TLrmIPmIu5uemAFJx4sNslRsJXfFxr hexa@helix";
 
   infra-core = [ eelco graham graham-hermes-conrad zimbatm amine vcunat ];
+  infra = infra-core ++ [
+    hexa-gaia
+    hexa-helix
+  ];
 }

--- a/ssh-keys.nix
+++ b/ssh-keys.nix
@@ -24,10 +24,12 @@ rec {
 
   hexa-gaia = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAWQRR7dspgQ6kCwyFnoVlgmmPR4iWL1+nvq6a5ad2Ug hexa@gaia";
   hexa-helix = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFSpdtIxIBFtd7TLrmIPmIu5uemAFJx4sNslRsJXfFxr hexa@helix";
+  julienmalka = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGa+7n7kNzb86pTqaMn554KiPrkHRGeTJ0asY1NjSbpr julien@tower";
 
   infra-core = [ eelco graham graham-hermes-conrad zimbatm amine vcunat ];
   infra = infra-core ++ [
     hexa-gaia
     hexa-helix
+    julienmalka
   ];
 }


### PR DESCRIPTION
Creates the `infra` key list and migrates hetzner-01 to run with it.

The wrong keys were deployed for me, so I had to access the host using the keypair I use for GitHub.

Fetching keys from GitHub is not great for key hygiene and did in fact cause a hash mismatch on Julien's keys.

@JulienMalka Please set up keys in `./ssh-keys.nix`, deploying all 14 keys from GitHub feels wrong.