### PR TITLE
public fastly logs

### DIFF
--- a/terraform/fastlylog/main.tf
+++ b/terraform/fastlylog/main.tf
@@ -21,6 +21,12 @@ resource "aws_s3_bucket" "logs" {
   }
 }
 
+# Allow third-parties to access the logs, but pay for the access.
+resource "aws_s3_bucket_request_payment_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  payer  = "Requester"
+}
+
 resource "aws_s3_bucket_policy" "logs" {
   bucket = aws_s3_bucket.logs.id
   policy = <<EOF
@@ -44,6 +50,19 @@ resource "aws_s3_bucket_policy" "logs" {
       },
       "Action": "s3:ListBucket",
       "Resource": "arn:aws:s3:::${aws_s3_bucket.logs.id}"
+    },
+    {
+      "Sid": "AllowRequesterPayReadOnly",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${aws_s3_bucket.logs.id}",
+        "arn:aws:s3:::${aws_s3_bucket.logs.id}/*"
+      ]
     }
   ]
 }

--- a/terraform/fastlylog/main.tf
+++ b/terraform/fastlylog/main.tf
@@ -10,13 +10,13 @@ resource "aws_s3_bucket" "logs" {
   }
 
   lifecycle_rule {
-    id = "move-to-glacier"
+    id = "move-to-infrequent-access"
 
     enabled = true
 
     transition {
-      days          = 14
-      storage_class = "DEEP_ARCHIVE"
+      days          = 30
+      storage_class = "ONEZONE_IA"
     }
   }
 }


### PR DESCRIPTION
Give access to the logs, so everybody can run their own analysis. The requester has to pay so it doesn't drain the foundation funds.

Eg:
```
aws s3 ls s3://fastly-logs-20220622145016462800000001/ --request-payer
```

