### PR TITLE
hydra-proxy: explicitly listen on ipv6 addresses

### DIFF
--- a/delft/hydra-proxy.nix
+++ b/delft/hydra-proxy.nix
@@ -58,6 +58,7 @@ in
           RewriteCond %{QUERY_STRING} ^query=pkgs.chromium$
           RewriteRule ^/search$ - [L,R=429,NC]
         '';
+        listenAddresses = [ "[::]" ];
         servedDirs =
           [ { urlPath = "/apache-errors";
               dir = ./apache-errors;


### PR DESCRIPTION
As reported in https://github.com/NixOS/nixos-org-configurations/issues/284 hydra is not currently accessible over ipv6 even though a AAAA record is published.

Apache is currently listening on only ipv4 addresses. This PR explicitly adds `[::]` to the listen address config so that ipv6 will be fully supported.

After change in test vm:

![image](https://github.com/NixOS/nixos-org-configurations/assets/2071575/203a531a-dff3-4612-8906-c455e5bbe0e6)


closes #284
