### PR TITLE
cache: add parquet inventory

### DIFF
--- a/terraform/cache_inventory.tf
+++ b/terraform/cache_inventory.tf
@@ -1,0 +1,43 @@
+# Get the list of files from the cache
+resource "aws_s3_bucket" "cache_inventory" {
+  provider = aws.us
+  bucket   = "nix-cache-inventory"
+
+  lifecycle_rule {
+    enabled = true
+
+    # Only keep the last 30 days
+    expiration {
+      days = 30
+    }
+  }
+}
+
+resource "aws_s3_bucket_inventory" "cache_inventory" {
+  provider = aws.us
+
+  bucket = aws_s3_bucket.cache.id
+  name   = "nix-cache-inventory"
+
+  included_object_versions = "Current"
+
+  optional_fields = [
+    "ETag",
+    "LastModifiedDate",
+    "Size",
+    "StorageClass",
+  ]
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  destination {
+    bucket {
+      account_id = "080433136561"
+      format     = "Parquet"
+      bucket_arn = aws_s3_bucket.cache_inventory.arn
+    }
+  }
+}
+


### PR DESCRIPTION
This makes it cheaper to traverse and analyze the S3 list of files.

This will be useful to answer a few questions like:
* what is the oldest file that we have?
* how much data is stored in what time ranges?
* give me the list of all .drv or .narinfo files in the bucket.
* how many files of which type do we have?
* what is the distribution of file sizes?