### PR TITLE
iam: add new user for fastly<->cache authn

### DIFF
--- a/terraform-iam/cache.tf
+++ b/terraform-iam/cache.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_user" "fastly-cache-access" {
+  name = "fastly-cache-access"
+}
+
+resource "aws_iam_access_key" "fastly-cache-access" {
+  user = aws_iam_user.fastly-cache-access.name
+}

--- a/terraform-iam/outputs.tf
+++ b/terraform-iam/outputs.tf
@@ -1,3 +1,11 @@
+output "cache" {
+  value = {
+    key = aws_iam_access_key.fastly-cache-access.id
+    secret = aws_iam_access_key.fastly-cache-access.secret
+  }
+  sensitive = true
+}
+
 output "fastlylogs" {
   value = module.fastlylogs
 }


### PR DESCRIPTION
Guessing at how things are architectured, lmk if that matches how you want the two Terraform codebases to be split and how you want data to be shared between the two.

Making this a separate PR so that @zimbatm (or someone else) can apply the diff early, and then I have an IAM identity ready to play with for the main change.

Ref #277

```
  # aws_iam_access_key.fastly-cache-access will be created
  + resource "aws_iam_access_key" "fastly-cache-access" {
      + create_date                    = (known after apply)
      + encrypted_secret               = (known after apply)
      + encrypted_ses_smtp_password_v4 = (known after apply)
      + id                             = (known after apply)
      + key_fingerprint                = (known after apply)
      + secret                         = (sensitive value)
      + ses_smtp_password_v4           = (sensitive value)
      + status                         = "Active"
      + user                           = "fastly-cache-access"
    }

  # aws_iam_user.fastly-cache-access will be created
  + resource "aws_iam_user" "fastly-cache-access" {
      + arn           = (known after apply)
      + force_destroy = false
      + id            = (known after apply)
      + name          = "fastly-cache-access"
      + path          = "/"
      + tags_all      = (known after apply)
      + unique_id     = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cache = (sensitive value)
```