### PR TITLE
dns, fastly: add cache-staging.nixos.org domain + TLS subscription

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -253,3 +253,9 @@ resource "fastly_tls_subscription" "cache" {
   configuration_id      = local.fastly_tls12_sni_configuration_id
   certificate_authority = "globalsign"
 }
+
+resource "fastly_tls_subscription" "cache-staging" {
+  domains               = ["cache-staging.nixos.org"]
+  configuration_id      = local.fastly_tls12_sni_configuration_id
+  certificate_authority = "globalsign"
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -107,6 +107,11 @@ locals {
       value    = "dualstack.v2.shared.global.fastly.net"
     },
     {
+      hostname = "cache-staging.nixos.org"
+      type     = "CNAME"
+      value    = "dualstack.v2.shared.global.fastly.net"
+    },
+    {
       hostname = "channels.nixos.org"
       type     = "CNAME"
       value    = "dualstack.v2.shared.global.fastly.net"


### PR DESCRIPTION
Splitting this out into a separate PR like #293 since I don't have permissions to add new TLS subscriptions.

The aim is to copy the current Fastly cache config to cache-staging.nixos.org so we can make sure the authn VCL works before pushing it to the main cache.nixos.org config.

DNS was already pushed:
```
$ host cache-staging.nixos.org
cache-staging.nixos.org is an alias for dualstack.v2.shared.global.fastly.net.
```

cc @zimbatm 
Ref #277