### PR TITLE
cache-staging: add fastly service configuration and test VCL for authentication

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -254,6 +254,159 @@ resource "fastly_tls_subscription" "cache" {
   certificate_authority = "globalsign"
 }
 
+# Temporarily duplicated while testing VCL fragment for Fastly<->S3 authn. TF
+# doesn't make it particularly easy to avoid this duplication.
+#
+# TODO: remove once the Fastly<->S3 authn is deployed to the main cache
+# Fastly service.
+resource "fastly_service_vcl" "cache-staging" {
+  name        = "cache-staging.nixos.org"
+  default_ttl = 86400
+
+  backend {
+    address               = "s3.amazonaws.com"
+    auto_loadbalance      = false
+    between_bytes_timeout = 10000
+    connect_timeout       = 5000
+    error_threshold       = 0
+    first_byte_timeout    = 15000
+    max_conn              = 200
+    name                  = "s3.amazonaws.com"
+    override_host         = aws_s3_bucket.cache.bucket_domain_name
+    port                  = 443
+    shield                = local.fastly_shield
+    ssl_cert_hostname     = "s3.amazonaws.com"
+    ssl_check_cert        = true
+    use_ssl               = true
+    weight                = 100
+  }
+
+  condition {
+    name      = "is-404"
+    priority  = 0
+    statement = "beresp.status == 404"
+    type      = "CACHE"
+  }
+
+  condition {
+    name      = "Match /"
+    priority  = 10
+    statement = "req.url ~ \"^/$\""
+    type      = "REQUEST"
+  }
+
+  domain {
+    name = "cache-staging.nixos.org"
+  }
+
+  header {
+    action            = "set"
+    destination       = "url"
+    ignore_if_set     = false
+    name              = "Landing page"
+    priority          = 10
+    request_condition = "Match /"
+    source            = "\"/index.html\""
+    type              = "request"
+  }
+
+  # Clean headers for caching
+  header {
+    destination = "http.x-amz-request-id"
+    type        = "cache"
+    action      = "delete"
+    name        = "remove x-amz-request-id"
+  }
+  header {
+    destination = "http.x-amz-version-id"
+    type        = "cache"
+    action      = "delete"
+    name        = "remove x-amz-version-id"
+  }
+  header {
+    destination = "http.x-amz-id-2"
+    type        = "cache"
+    action      = "delete"
+    name        = "remove x-amz-id-2"
+  }
+
+  # Enable Streaming Miss.
+  # https://docs.fastly.com/en/guides/streaming-miss
+  # https://github.com/NixOS/nixos-org-configurations/issues/212#issuecomment-1187568233
+  header {
+    priority    = 20
+    destination = "do_stream"
+    type        = "cache"
+    action      = "set"
+    name        = "Enabling Streaming Miss"
+    source      = "true"
+  }
+
+  # Allow CORS GET requests.
+  header {
+    destination = "http.access-control-allow-origin"
+    type        = "response"
+    action      = "set"
+    name        = "CORS Allow"
+    source      = "\"*\""
+  }
+
+  response_object {
+    name            = "404-page"
+    cache_condition = "is-404"
+    content         = "404"
+    content_type    = "text/plain"
+    response        = "Not Found"
+    status          = 404
+  }
+
+  # Authenticate Fastly<->S3 requests. See Fastly documentation:
+  # https://docs.fastly.com/en/guides/amazon-s3#using-an-amazon-s3-private-bucket
+  snippet {
+    name = "Authenticate S3 requests"
+    type = "miss"
+    priority = 100
+    content = templatefile("${path.module}/cache/s3-authn.vcl", {
+      aws_region = aws_s3_bucket.cache.region
+      backend_domain = aws_s3_bucket.cache.bucket_domain_name
+      access_key = local.cache-iam.key
+      secret_key = local.cache-iam.secret
+    })
+  }
+
+  snippet {
+    content  = "set req.url = querystring.remove(req.url);"
+    name     = "Remove all query strings"
+    priority = 50
+    type     = "recv"
+  }
+
+  # Work around the 2GB size limit for large files
+  #
+  # See https://docs.fastly.com/en/guides/segmented-caching
+  snippet {
+    content  = <<-EOT
+      if (req.url.path ~ "^/nar/") {
+        set req.enable_segmented_caching = true;
+      }
+    EOT
+    name     = "Enable segment caching for NAR files"
+    priority = 60
+    type     = "recv"
+  }
+
+  snippet {
+    name     = "cache-errors"
+    content  = <<-EOT
+      if (beresp.status == 403) {
+        set beresp.status = 404;
+      }
+    EOT
+    priority = 100
+    type     = "fetch"
+  }
+}
+
 resource "fastly_tls_subscription" "cache-staging" {
   domains               = ["cache-staging.nixos.org"]
   configuration_id      = local.fastly_tls12_sni_configuration_id

--- a/terraform/cache/s3-authn.vcl
+++ b/terraform/cache/s3-authn.vcl
@@ -1,0 +1,65 @@
+# VCL snippet to authenticate Fastly<->S3 requests.
+#
+# https://docs.fastly.com/en/guides/amazon-s3#using-an-amazon-s3-private-bucket
+
+declare local var.canonicalHeaders STRING;
+declare local var.signedHeaders STRING;
+declare local var.canonicalRequest STRING;
+declare local var.canonicalQuery STRING;
+declare local var.stringToSign STRING;
+declare local var.dateStamp STRING;
+declare local var.signature STRING;
+declare local var.scope STRING;
+
+if (req.method == "GET" && !req.backend.is_shield) {
+  set bereq.http.x-amz-content-sha256 = digest.hash_sha256("");
+  set bereq.http.x-amz-date = strftime({"%Y%m%dT%H%M%SZ"}, now);
+  set bereq.http.x-amz-request-payer = "requester";
+  set bereq.http.host = "${backend_domain}";
+  set bereq.url = querystring.remove(bereq.url);
+  set bereq.url = regsuball(urlencode(urldecode(bereq.url.path)), {"%2F"}, "/");
+  set var.dateStamp = strftime({"%Y%m%d"}, now);
+  set var.canonicalHeaders = ""
+    "host:" bereq.http.host LF
+    "x-amz-content-sha256:" bereq.http.x-amz-content-sha256 LF
+    "x-amz-date:" bereq.http.x-amz-date LF
+    "x-amz-request-payer:" bereq.http.x-amz-request-payer LF
+  ;
+  set var.canonicalQuery = "";
+  set var.signedHeaders = "host;x-amz-content-sha256;x-amz-date;x-amz-request-payer";
+  set var.canonicalRequest = ""
+    "GET" LF
+    bereq.url.path LF
+    var.canonicalQuery LF
+    var.canonicalHeaders LF
+    var.signedHeaders LF
+    digest.hash_sha256("")
+  ;
+
+  set var.scope = var.dateStamp "/${aws_region}/s3/aws4_request";
+
+  set var.stringToSign = ""
+    "AWS4-HMAC-SHA256" LF
+    bereq.http.x-amz-date LF
+    var.scope LF
+    regsub(digest.hash_sha256(var.canonicalRequest),"^0x", "")
+  ;
+
+  set var.signature = digest.awsv4_hmac(
+    "${secret_key}",
+    var.dateStamp,
+    "${aws_region}",
+    "s3",
+    var.stringToSign
+  );
+
+  set bereq.http.Authorization = "AWS4-HMAC-SHA256 "
+    "Credential=${access_key}/" var.scope ", "
+    "SignedHeaders=" var.signedHeaders ", "
+    "Signature=" + regsub(var.signature,"^0x", "")
+  ;
+  unset bereq.http.Accept;
+  unset bereq.http.Accept-Language;
+  unset bereq.http.User-Agent;
+  unset bereq.http.Fastly-Client-IP;
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -6,6 +6,7 @@ locals {
 
   fastly_shield = "iad-va-us"
 
+  cache-iam = data.terraform_remote_state.terraform-iam.outputs.cache
   fastlylogs = data.terraform_remote_state.terraform-iam.outputs.fastlylogs
 
   # fastlylogs = {


### PR DESCRIPTION
This authenticates Fastly requests for cache-staging.nixos.org going to the cache S3 bucket, and sets the request-payer: "requester" header (which might be required if the IAM user is not in the same project as the S3 bucket).

Deployed already and https://cache-staging.nixos.org/nix-cache-info seems to work as expected.

Note that this duplicates the Terraform config for the cache Fastly service, because Terraform is pain and there's no way to e.g. inherit from a resource to apply selective overrides. The only differences between the two services should be:
1. cache.nixos.org -> cache-staging.nixos.org
2. no S3 logging
3. the authn VCL

Ref #277