### PR TITLE
ci: add a "terraform fmt" check on pushes/PRs

### DIFF
--- a/.github/workflows/terraform-fmt.yml
+++ b/.github/workflows/terraform-fmt.yml
@@ -1,0 +1,24 @@
+name: Check Terraform formatting
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check terraform/ formatting
+      uses: dflook/terraform-fmt-check@v1
+      with:
+        path: terraform
+
+    - name: Check terraform-iam/ formatting
+      uses: dflook/terraform-fmt-check@v1
+      with:
+        path: terraform-iam


### PR DESCRIPTION
Attempt at preventing spurious diffs when people like me don't know or forget that `terraform fmt` is a thing :-)

Not technically perfect since it's not using the `terraform` version from nixpkgs or the `flake.lock`, but likely good enough. If it causes problems, we can fix it later.