### PR TITLE
terraform: cache: configure as Requester Pays

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -101,6 +101,12 @@ resource "aws_s3_bucket_policy" "cache" {
 EOF
 }
 
+resource "aws_s3_bucket_request_payment_configuration" "cache" {
+  provider = aws.us
+  bucket   = aws_s3_bucket.cache.id
+  payer    = "Requester"
+}
+
 resource "fastly_service_vcl" "cache" {
   name        = local.cache_domain
   default_ttl = 86400


### PR DESCRIPTION
Not applied yet, will apply on 2023-11-04 (Saturday).

```
  # aws_s3_bucket_request_payment_configuration.cache will be created
  + resource "aws_s3_bucket_request_payment_configuration" "cache" {
      + bucket = "nix-cache"
      + id     = (known after apply)
      + payer  = "Requester"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Will merge once applied and tested to not explode, filing this PR to get any review feedback prior to applying later this week.

Fixes #277 