### PR TITLE
terraform: give archaeologist IAM policy permission to access cache_log bucket

### DIFF
--- a/terraform-iam/archeologist.tf
+++ b/terraform-iam/archeologist.tf
@@ -31,6 +31,17 @@ resource "aws_iam_policy" "archologist" {
             ]
         },
         {
+            "Sid": "NixCacheLogsReadOnly",
+            "Effect": "Allow",
+            "Action": [
+                "s3:Get*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::nix-cache-log",
+                "arn:aws:s3:::nix-cache-log/*"
+            ]
+        },
+        {
             "Sid": "NixArcheologistReadWrite",
             "Effect": "Allow",
             "Action": [ "s3:*" ],


### PR DESCRIPTION
This currently only seems accessible from the SSO users, not the instance role.

This will allow automated processing of bucket logs.

See https://cs.tvl.fyi/depot/-/commit/281cb93ba808b73d4ea4ce86f762bbcb504a09da for context.

cc @zimbatm 