### PR TITLE
allow bucket object listing

### DIFF
--- a/terraform-iam/archeologist.tf
+++ b/terraform-iam/archeologist.tf
@@ -6,6 +6,51 @@ resource "aws_s3_bucket" "archeologist" {
   bucket = "nix-archeologist"
 }
 
+data "aws_iam_policy_document" "archaeologist" {
+  statement {
+    sid = "NixCacheInventoryReadOnly"
+
+    actions = [
+      "s3:Get*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::nix-cache-inventory",
+      "arn:aws:s3:::nix-cache-inventory/*",
+      "arn:aws:s3:::nix-cache-log",
+      "arn:aws:s3:::nix-cache-log/*",
+      "arn:aws:s3:::nix-releases-inventory220231029182031496800000001",
+      "arn:aws:s3:::nix-releases-inventory220231029182031496800000001/*"
+    ]
+  }
+
+  statement {
+    sid = "NixCacheLogsReadOnly"
+
+    actions = [
+      "s3:Get*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::nix-cache-log",
+      "arn:aws:s3:::nix-cache-log/*"
+    ]
+  }
+
+  statement {
+    sid = "NixArcheologistReadWrite"
+
+    actions = [
+      "s3:*"
+    ]
+
+    resources = [
+      aws_s3_bucket.archeologist.arn,
+      "${aws_s3_bucket.archeologist.arn}/*"
+    ]
+  }
+}
+
 # This is the role that is given to the AWS Identity Center users
 resource "aws_iam_policy" "archologist" {
   provider = aws.us
@@ -13,46 +58,7 @@ resource "aws_iam_policy" "archologist" {
   name        = "archeologist"
   description = "used by the S3 archeologists"
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "NixCacheInventoryReadOnly",
-            "Effect": "Allow",
-            "Action": [
-                "s3:Get*"
-            ],
-            "Resource": [
-                "arn:aws:s3:::nix-cache-inventory",
-                "arn:aws:s3:::nix-cache-inventory/*",
-                "arn:aws:s3:::nix-releases-inventory220231029182031496800000001",
-                "arn:aws:s3:::nix-releases-inventory220231029182031496800000001/*"
-            ]
-        },
-        {
-            "Sid": "NixCacheLogsReadOnly",
-            "Effect": "Allow",
-            "Action": [
-                "s3:Get*"
-            ],
-            "Resource": [
-                "arn:aws:s3:::nix-cache-log",
-                "arn:aws:s3:::nix-cache-log/*"
-            ]
-        },
-        {
-            "Sid": "NixArcheologistReadWrite",
-            "Effect": "Allow",
-            "Action": [ "s3:*" ],
-            "Resource": [
-                "${aws_s3_bucket.archeologist.arn}",
-                "${aws_s3_bucket.archeologist.arn}/*"
-            ]
-        }
-    ]
-}
-EOF
+  policy = data.aws_iam_policy_document.archaeologist.json
 }
 
 # Prepare this role to be attached to the EC2 instance

--- a/terraform-iam/archeologist.tf
+++ b/terraform-iam/archeologist.tf
@@ -8,9 +8,13 @@ resource "aws_s3_bucket" "archeologist" {
 
 data "aws_iam_policy_document" "archaeologist" {
   statement {
-    sid = "NixCacheInventoryReadOnly"
+    # Read-only access and listing permissions
+    # To the cache and releases inventories,
+    # as well as the bucket where cache bucket logs end up in.
+    sid = "NixCacheLogsInventoryReadOnly"
 
     actions = [
+      "s3:List*",
       "s3:Get*"
     ]
 
@@ -33,12 +37,15 @@ data "aws_iam_policy_document" "archaeologist" {
 
     resources = [
       "arn:aws:s3:::nix-cache-log",
-      "arn:aws:s3:::nix-cache-log/*"
+      "arn:aws:s3:::nix-cache-log/*",
+      "arn:aws:s3:::nix-releases-inventory220231029182031496800000001",
+      "arn:aws:s3:::nix-releases-inventory220231029182031496800000001/*",
     ]
   }
 
   statement {
-    sid = "NixArcheologistReadWrite"
+    # Full access to the Archaeologist bucket
+    sid = "NixArchaeologistReadWrite"
 
     actions = [
       "s3:*"


### PR DESCRIPTION
```
commit c483e95aa1841f580e7c58465c3eefa334e3afde
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 11 19:51:58 2023 +0200

    terraform-iam: fix listing for nix-cache-logs and others (hopefully)
    
    This adds support for the ListObjects[V2] actions, which should allow
    listing the contents in there.

commit 0e8f09c139c80346679d1ac4b49a25b50d895ae0
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 11 19:43:49 2023 +0200

    terraform-iam: convert to aws_iam_policy_document
    
    This makes it a bit easier to write these policies. It's a mechanical
    conversion from the previous version.
```