### PR TITLE
cache_log: expire bucket logs after 30 days

### DIFF
--- a/terraform/cache_log.tf
+++ b/terraform/cache_log.tf
@@ -22,13 +22,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "cache_log" {
     id     = "rule-1"
     status = "Enabled"
 
-    transition {
-      days          = 30
-      storage_class = "ONEZONE_IA"
-    }
-
     expiration {
-      days = "120"
+      days = "30"
     }
   }
 }


### PR DESCRIPTION
Since https://cs.tvl.fyi/depot/-/commit/e4adca0880547f2ea825aeec5f64671c6c0324ae the archaeology ec2 instance aggregates logs daily at 3am UTC, so there's no need to keep it around for 120 days.

We can delete it after 30 days, rather than moving it to IA.

Theoretically, we could even delete it after a day or two, but this gives us some slack to notice the job aggregation failed.

cc @zimbatm 