### PR TITLE
umbriel: migrate mjolnir from eris

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -10,7 +10,6 @@ in
     ./eris/github-project-monitor.nix
     ./eris/alertmanager-matrix-forwarder.nix
     ./eris/channel-monitor.nix
-    ./eris/mjolnir.nix
   ];
   deployment.targetEnv = "hetzner";
   deployment.hetzner.mainIPv4 = "138.201.32.77";

--- a/non-critical-infra/.sops.yaml
+++ b/non-critical-infra/.sops.yaml
@@ -2,13 +2,22 @@ keys:
   - &hexa age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x
   - &julienmalka age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976
   - &zimbatm age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h
-  - &hetzner01 age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq
+  - &caliban age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq
+  - &umbriel age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6
+
 creation_rules:
   - path_regex: secrets/[^/]+.caliban
     key_groups:
     - age:
+      - *caliban
       - *hexa
       - *julienmalka
       - *zimbatm
-      - *hetzner01
 
+  - path_regex: secrets/[^/]+.umbriel
+    key_groups:
+    - age:
+      - *umbriel
+      - *hexa
+      - *julienmalka
+      - *zimbatm

--- a/non-critical-infra/flake.nix
+++ b/non-critical-infra/flake.nix
@@ -63,6 +63,7 @@
             buildInputs = with pkgs; [
               colmena.packages.${system}.colmena
               sops
+              ssh-to-age
             ];
           };
       });

--- a/non-critical-infra/hosts/umbriel.nixos.org/default.nix
+++ b/non-critical-infra/hosts/umbriel.nixos.org/default.nix
@@ -6,6 +6,7 @@
       ./hardware.nix
       inputs.srvos.nixosModules.server
       inputs.srvos.nixosModules.hardware-hetzner-cloud-arm
+      ../../modules/mjolnir.nix
     ];
 
   # Bootloader.

--- a/non-critical-infra/modules/mjolnir.nix
+++ b/non-critical-infra/modules/mjolnir.nix
@@ -1,15 +1,16 @@
-{ config, lib, ... }:
+{ lib
+, ...
+}:
 {
-  deployment.keys = {
-    "mjolnir.password" = {
-      keyFile = /home/deploy/src/nixos-org-configurations/keys/mjolnir-password;
-      user = config.systemd.services.mjolnir.serviceConfig.User;
-      group = "keys";
-      permissions = "0600";
-    };
+  sops.secrets.first-time-contribution-tagger-env = {
+    sopsFile = ../secrets/mjolnir-password.umbriel;
+    format = "binary";
+    path = "/var/keys/mjolnir.password";
+    mode = "0640";
+    owner = "root";
+    group = "mjolnir";
   };
 
-  systemd.services.mjolnir.serviceConfig.SupplementaryGroups = [ "keys" ];
   # pantalaimon takes ages to start up, so mjolnir could hit the systemd burst
   # limit and then just be down forever. We don't want mjolnir to ever go down,
   # so disable rate-limiting and allow it to flap until pantalaimon is alive.
@@ -26,7 +27,7 @@
     pantalaimon = {
       enable = true;
       username = "mjolnir";
-      passwordFile = "/run/keys/mjolnir.password";
+      passwordFile = "/var/keys/mjolnir.password";
       options = {
         listenAddress = "[::1]";
       };

--- a/non-critical-infra/secrets/mjolnir-password.umbriel
+++ b/non-critical-infra/secrets/mjolnir-password.umbriel
@@ -1,0 +1,32 @@
+{
+	"data": "ENC[AES256_GCM,data:GMHlNuJT6oR0jCWyVaYdFxhMw6XGlMaxV7ysobHz6Io=,iv:X81JEKLt0Xg4+rGAp8nPcyq5fYQY7CQzYAG4FfKVZX8=,tag:husw5zwOuMsEREGK19qUWQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsOUlLYnBzcVgzY2o2YXdV\nUzdBdUIvUUptclFxWGF1S0lwUm1iVUNHeDBNCkVBeXFoaEcvbjJRRmNzbUZaWi93\nNlQxQk9nRGhMd0FnMWRadmRZaHZwMjAKLS0tIHU5S01QNExEdHdja0VnRUJxdjEz\nc1FwWDV6MC9BWXlucmdmSFdTV3JVSGsKuUL+N48N/aD7nKsm77gM33crAuGBTK3c\nV9H4vEYOvbpn49Y6ayVM2ct6uyFARwy7aO20YamtdD0DQ8hxJxnVFw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFTXlrYS9OeGgyZGtqWUVl\nWjQvdkJocVdveVJGd0Z2Qm55Qml0d2dDSXpjCkovVHFQUko2UkZSRURzbTY5UEh2\nZ2dPVDJZbi9JNXM1bnREMk1Td0QvZXcKLS0tIFNqWXo2ejFoZ0FOQVAzNFdudnEw\nb2pNMFBEUXhFbUVkTHdxRGMzMXZQVmsKl/Zcaio6CqCTGs4rKM6gKFQainEDzvE7\n82ynmkxeI16lvOa+xj5v323I13tQTMyakL9J/mWYDnKPXjuQQa4yPQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2OHJEOSt0bTlIcld0Y3dJ\nOW9xRHh3bzBiV2NtOXQ1TjVKTmJMYXduMDBnCjJkbDlPY3o0NWNBQkNVRnI3eERU\na0tnYXBEa1NUSWt3ak1IaDdDQllPM2MKLS0tIGNZVlY3eXFvcUFBaHlkK1F1dzVa\ndjMwbE9DV3BVWWZjQVMycFRweFJ2a3cK5yqRTOjj/0Xb9CEEHwltQZKihp8c9Hl2\nv03vd88w9tZ3sTbOcyHcqqNWmxinYjeKEhve6ktfn4R1eMBTnX8CVg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWUzNoUEFyb1lPZkw5TDBv\nQnY5Y2JUUUlEZVB2YWdIelNhVjcweUNraXdFClJmekdOMjloNFNqQWlzT1RyVll4\nWkZUUVRzNWcwM2VBNkV5eEhha1h6aXMKLS0tIGxpU3JTaTlkM1pJNHppZmZ3dk9n\nZ0ZrQk1hcmpZN2hhUUI3N29RTjRDQTAKzKzakgdLduTXXXIFZPy+5mNPHnwDYmib\noekwJI6fVZcxCXdVR5VmHQH4w70joCFTK9HNlZTdyspHUfBbBEqXsw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2023-11-14T18:58:37Z",
+		"mac": "ENC[AES256_GCM,data:zk3/qHNxqpctBJrrXjUaOunPHH02jiCeIuNIAhI5R3s7fhakrIJtLFP/KSH836wis+3+MnCMiqda9FHMd750uC2nH52jNW9Ywc1VJkWaygUZLhXZfObGND4u7e58VYQgPRPiuP8V6Q6Xcqm1vo+4ntpU/906e5tugqE8kxFH4CI=,iv:wC1bgksS1k2LXhIk0VTQ6oee8vY4AiW1Do1u2snL0iQ=,tag:6cuuqRFTUNXNpWD3dh/D2A==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}


### PR DESCRIPTION
This migrates Mjölnir and its E2EE proxy pantalaimon to infrastructure maintained by the non-critical-infra team, to unblock maintenance on it.

Already deployed and running on umbriel.nixos.org. Eris needs to be redeployed to remove the service.