### PR TITLE
Put myself in the same list as the other `makemake` wheel users

### DIFF
--- a/ngi0/makemake/flake.nix
+++ b/ngi0/makemake/flake.nix
@@ -101,7 +101,7 @@
           boot.loader.grub.copyKernels = true;
 
           users.extraUsers.root.openssh.authorizedKeys.keys =
-            with import ../../ssh-keys.nix; ngi-admins ++ [ john-ericson ];
+            (import ../../ssh-keys.nix).ngi-admins;
         })
       ];
     };

--- a/ssh-keys.nix
+++ b/ssh-keys.nix
@@ -50,5 +50,5 @@ rec {
     julienmalka
   ];
 
-  ngi-admins = infra-core ++ [ regnat cleeyv lorenz-leutgeb tomberek ];
+  ngi-admins = infra-core ++ [ regnat cleeyv lorenz-leutgeb tomberek john-ericson ];
 }


### PR DESCRIPTION
`ngi-admins` is only used by this, so this doesn't change the meaning of the code, it just folds a special case (me) into a common case (the other non-core "NGI admins").

C.F. f587218f44f2e7827f85bea3ec77d02541993a0d