### PR TITLE
eris,haumea: allow infra-core members to SSH without nixops ssh

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -15,6 +15,8 @@ in
   deployment.targetEnv = "hetzner";
   deployment.hetzner.mainIPv4 = "138.201.32.77";
 
+  users.users.root.openssh.authorizedKeys.keys =
+    with import ../ssh-keys.nix; infra-core;
 
   networking.extraHosts = ''
     10.254.1.1 bastion

--- a/delft/haumea.nix
+++ b/delft/haumea.nix
@@ -12,6 +12,9 @@
   deployment.targetEnv = "hetzner";
   deployment.hetzner.mainIPv4 = "46.4.89.205";
 
+  users.users.root.openssh.authorizedKeys.keys =
+    with import ../ssh-keys.nix; infra-core;
+
   deployment.hetzner.partitionCommand =
     ''
       if ! [ -e /usr/local/sbin/zfs ]; then


### PR DESCRIPTION
As per #324. This is already how `rhea` is configured.

This configuration is duplicated for now, there are plenty of refactorings to come, but I'm doing that after getting rid of nixops because until then I can't even `nix build` the configs locally without using a nixops version that's not in nixpkgs anymore...