### PR TITLE
wireguard-hosts: add hexa-helix

### DIFF
--- a/modules/wireguard-hosts.toml
+++ b/modules/wireguard-hosts.toml
@@ -112,3 +112,8 @@ publicKey = "pH2DCtTti9gbyYZ4jFHnhjwDGlWTGKlJ7HFl9ykYjz8="
 ip = "10.254.4.5"
 port = 51820
 publicKey = "1PLQcx+eVLgRwN6e7fim53rHQXB7pjIg6okOe2nFoi8="
+
+[hosts.hexa-helix]
+# hexa's machine (@mweinelt), for administrative access
+ip = "10.254.4.6"
+publicKey = "Aco4hlJFNYtSzZDT6O0TtopnBl76e7aoubI6QygNrGM="


### PR DESCRIPTION
I decided against adding a port, since my end is floating anyway.