### PR TITLE
delft/eris: don't alert on space/inode issues on packet nodes

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -197,7 +197,7 @@ in
             name = "system";
             rules =
               let
-                diskSelector = ''mountpoint=~"(/|/scratch)"'';
+                diskSelector = ''mountpoint=~"(/|/scratch)",instance!~=".*packethost.net"'';
                 relevantLabels = "device,fstype,instance,mountpoint";
               in
               [


### PR DESCRIPTION
The way they're set up makes this alert far too noisy and unactionable.

Closes: #331