### PR TITLE
rhea: scale less

### DIFF
--- a/delft/hydra-scaler.nix
+++ b/delft/hydra-scaler.nix
@@ -15,9 +15,9 @@
       categories = {
         aarch64-linux = {
           bigparallel = {
-            divisor = 5;
+            divisor = 20;
             minimum = 1;
-            maximum = 5;
+            maximum = 4;
             plans = [
               {
                 bid = 2.0;
@@ -27,9 +27,9 @@
             ];
           };
           small = {
-            divisor = 2000;
-            minimum = 1;
-            maximum = 5;
+            divisor = 4000;
+            minimum = 0; # we have one static 80-core in addition
+            maximum = 3;
             plans = [
               {
                 bid = 2.0;
@@ -41,7 +41,7 @@
         };
         x86_64-linux = rec {
           bigparallel = {
-            divisor = 5;
+            divisor = 10;
             minimum = 1;
             maximum = 5;
             plans = [
@@ -60,7 +60,7 @@
           small = {
             divisor = 2000;
             minimum = 1;
-            maximum = 5;
+            maximum = 4;
             plans = [
               {
                 bid = 2.0;


### PR DESCRIPTION
It's been commonly hapenning that we spin up many machines but can't keep them occupied due to bottlenecks in the central machine (probably it's mostly the compression of copying-results step)

So let's scale less aggressively and thus waste less.