### PR TITLE
non-critical-infra/backup: init and configure on caliban

### DIFF
--- a/non-critical-infra/hosts/caliban.nixos.org/default.nix
+++ b/non-critical-infra/hosts/caliban.nixos.org/default.nix
@@ -7,6 +7,7 @@
       inputs.srvos.nixosModules.server
       inputs.srvos.nixosModules.hardware-hetzner-online-amd
       ../../modules/first-time-contribution-tagger.nix
+      ../../modules/backup.nix
     ];
 
   # Bootloader.
@@ -41,6 +42,34 @@
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:5a:186c::2";
 
   users.users.root.openssh.authorizedKeys.keys = (import ../../../ssh-keys.nix).infra;
+
+  sops.secrets.storagebox-ssh-key = {
+    sopsFile = ../../secrets/storagebox-ssh-key.caliban;
+    format = "binary";
+    path = "/var/keys/storagebox-ssh-key";
+    mode = "0600";
+    owner = "root";
+    group = "root";
+  };
+
+  sops.secrets.backup-secret = {
+    sopsFile = ../../secrets/backup-secret.caliban;
+    format = "binary";
+    path = "/var/keys/borg-secret";
+    mode = "0600";
+    owner = "root";
+    group = "root";
+  };
+
+  services.backup = {
+    user = "u371748";
+    host = "u371748.your-storagebox.de";
+    hostPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EB5p/5Hp3hGW1oHok+PIOH9Pbn7cnUiGmUEBrCVjnAw+HrKyN8bYVV0dIGllswYXwkG/+bgiBlE6IVIBAq+JwVWu1Sss3KarHY3OvFJUXZoZyRRg/Gc/+LRCE7lyKpwWQ70dbelGRyyJFH36eNv6ySXoUYtGkwlU5IVaHPApOxe4LHPZa/qhSRbPo2hwoh0orCtgejRebNtW5nlx00DNFgsvn8Svz2cIYLxsPVzKgUxs8Zxsxgn+Q/UvR7uq4AbAhyBMLxv7DjJ1pc7PJocuTno2Rw9uMZi1gkjbnmiOh6TTXIEWbnroyIhwc8555uto9melEUmWNQ+C+PwAK+MPw==";
+    port = 23;
+    sshKey = config.sops.secrets.storagebox-ssh-key.path;
+    secretPath = config.sops.secrets.backup-secret.path;
+    quota = "90G"; # of 100G
+  };
 
   system.stateVersion = "23.05";
 

--- a/non-critical-infra/modules/backup.nix
+++ b/non-critical-infra/modules/backup.nix
@@ -1,0 +1,162 @@
+{ lib
+, config
+, ...
+}:
+
+let
+  cfg = config.services.backup;
+in
+{
+  options.services.backup = with lib; with types; {
+    user = mkOption {
+      type = str;
+      description = ''
+        Username for the SSH remote host.
+      '';
+    };
+
+    host = mkOption {
+      type = str;
+      description = ''
+        Hostname of the SSH remote host.
+      '';
+    };
+
+    hostPublicKey = mkOption {
+      type = str;
+      example = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EB5p/5Hp3hGW1oHok+PIOH9Pbn7cnUiGmUEBrCVjnAw+HrKyN8bYVV0dIGllswYXwkG/+bgiBlE6IVIBAq+JwVWu1Sss3KarHY3OvFJUXZoZyRRg/Gc/+LRCE7lyKpwWQ70dbelGRyyJFH36eNv6ySXoUYtGkwlU5IVaHPApOxe4LHPZa/qhSRbPo2hwoh0orCtgejRebNtW5nlx00DNFgsvn8Svz2cIYLxsPVzKgUxs8Zxsxgn+Q/UvR7uq4AbAhyBMLxv7DjJ1pc7PJocuTno2Rw9uMZi1gkjbnmiOh6TTXIEWbnroyIhwc8555uto9melEUmWNQ+C+PwAK+MPw==";
+      description = ''
+        Public SSH host key of the remote host. Discoverable using e.g. `ssh-keyscan`.
+      '';
+    };
+
+    port = mkOption {
+      type = port;
+      default = 22;
+      description = ''
+        Port of the SSH remote host.
+      '';
+      apply = toString;
+    };
+
+    sshKey = mkOption {
+      type = path;
+      example = "/var/keys/ssh-key";
+      description = ''
+        Path to the SSH key required to access the remote host.
+      '';
+    };
+
+    secretPath = mkOption {
+      type = path;
+      example = "/var/keys/borg-secret";
+      description = ''
+        Path to the secret used to encrypt backups in the repository.
+      '';
+    };
+
+    quota = mkOption {
+      type = nullOr str;
+      default = null;
+      example = "90G";
+      description = ''
+        Quota for the borg repository. Useful to prevent the target disk from running full and ensuring borg keeps some space to work with.
+      '';
+    };
+
+    includes = mkOption {
+      type = listOf path;
+      default = [];
+      description = ''
+        Paths to include in the backup.
+      '';
+    };
+
+    excludes = mkOption {
+      type = listOf path;
+      default = [];
+      description = ''
+        Paths to exclude in the backup.
+      '';
+    };
+
+    preHook = mkOption {
+      type = lines;
+      default = "";
+      description = ''
+        Shell commands to run before the backup.
+      '';
+    };
+
+    postHook = mkOption {
+      type = lines;
+      default = "";
+      description = ''
+        Shell commands to run after the backup.
+      '';
+    };
+
+    wantedUnits = mkOption {
+      type = listOf str;
+      default = [];
+      description = ''
+        List of units to require before starting the backup.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.includes != []) {
+    programs.ssh.knownHosts."${if cfg.port != 22 then "[${cfg.host}]:${cfg.port}" else cfg.host}" = {
+      publicKey = "${cfg.hostPublicKey}";
+    };
+
+    systemd.services.borgbackup-job-state = {
+      wants = cfg.wantedUnits;
+      after = cfg.wantedUnits;
+    };
+
+    systemd.timers.borgbackup-job-state.timerConfig = {
+      # Spread all backups over the day
+      RandomizedDelaySec = "24h";
+      FixedRandomDelay = true;
+    };
+
+    services.borgbackup.jobs.state = {
+      inherit (cfg) preHook postHook;
+
+      # Create the repo
+      doInit = true;
+
+      # Create daily backups, but prune to a reasonable amount
+      startAt = "daily";
+      prune.keep = {
+        daily = 7;
+        weekly = 4;
+        monthly = 3;
+      };
+
+      # What to backup
+      paths = cfg.includes;
+      exclude = cfg.excludes;
+
+      # Where to backup it to
+      repo = "${cfg.user}@${cfg.host}:${config.networking.fqdn}/repo";
+      environment.BORG_RSH = "ssh -p ${cfg.port} -i ${cfg.sshKey}";
+
+      # Ensure we don't fill up the destination disk
+      extraInitArgs = lib.optionalString (cfg.quota != null) "--storage-quota ${cfg.quota}";
+
+      # Authenticated & encrypted, key resides in the repository
+      encryption = {
+        mode = "repokey-blake2";
+        passCommand = "cat ${cfg.secretPath}";
+      };
+
+      # Reduce the backup size
+      compression = "auto,zstd";
+
+      # Show summary detailing data usage once completed
+      extraCreateArgs = "--stats";
+    };
+  };
+}

--- a/non-critical-infra/secrets/backup-secret.caliban
+++ b/non-critical-infra/secrets/backup-secret.caliban
@@ -1,0 +1,32 @@
+{
+	"data": "ENC[AES256_GCM,data:X4VUnWfPTrCzfc16/+korcEI0sExkevl6vqHXm8E+WwbmIRJu4gITwM2278swsp/wzq5zrRHNewzZpFtXp85HCY=,iv:S4KPDjH5SW4hh5X9NVjrz9Dvd/Fpnd/b8pLlDYiHzzI=,tag:Ls1aJtXfP8wW4w8F/DGsOQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBycEh4OTM4d0J5N0pyOTA4\neDliTjFYL1lzNUc2M0NBRDVIcnFKNEJla1RZCmg4M2lKWnArWGNjNzk5cFBHV1h3\naTNNWHhMbXFtNWNzRXhRM0Q1YzlSOTQKLS0tIE8walJxY2k3TW9oRVVZbEZPS0V3\nTWo2Q3RVV0N2VGVjQUxNTUpsQi9qVUEKfAgRqP2RBWDB42Ut/At9bRfhBmMYsUXR\nsYtyP1waOU65FKNmL6Im24OWYa9tLi39V5fTadi3e5MV3OmE6WRYWQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlZWJ3M0thdzFYUTMvcWc5\nL1hUenMrdHU2RVRLcS9KU3V5SHlJSlZub0hvCjZ2b2E0N0xLOXdUbElQa2huM21v\nNG5DblZJeXpadExtUjBpRWV1eHV1N1kKLS0tIGdjRTBLSk95NlNpVElFVmVRQnpQ\nbzhmREgwK3ZHN2JwVWZJbjBqSklMRUEKIozBlvYMxb4v3DnUARAL9UBvr/Mbhgq2\nzYkont0oNowlns4pHeC2/rN6ES/oK4PyXmdrEMwcLSo5Y9KNuBWE0g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1MVFsbnB3eURLWk9yWnBJ\nWUtlOVlBUzFIMjBMUXNIZWRQeDQvNFVJSVRjCjhvU1R5TnNUWFJwRkxsYXZBRlRP\nL2pXTjc4QUxMVzNQaVhRRVNPbUw1MzAKLS0tIEY2dTloc3Q5dTFDUXI2UGtDNjBv\nNEhDTXpVaDZwNXJKMmVGN3ZGbmlYKzgK268c0T2MNlrU1r/dwdwr9Per+VLWxb+m\n6VL/etWMx4jL4JfYbi6Bk35PwGM/WfdZErnUvIQv+56qGZ9eMIETXg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1YlQwWmU3SDFVM0ZBZzBK\nNkFraVkvOG9lNHF5QjNqYzRXWGQ4ai92eFYwCnhBNlhUc2Z0TTdsUmlYWmFSTzFM\nODJ4QUZPbnhmODN5c2JMT2hPUWFnZ28KLS0tIFZKbVRPUHdJL3hqKzlwRGptR2M4\nTjE1b21xWFVFR3J1azdtUjlXTDVLbjAKfc2/NhPiecmp3wRoFOE8iIAihNvOdQ++\n4m0HLOlTU6b5N0myCutbj1Uug7cVY6L6Vivxe7Zp25W0v1z0m5didQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2024-01-29T15:17:00Z",
+		"mac": "ENC[AES256_GCM,data:i/EHL4LBLixq3dhsIIdO0yMMBY19v7/4ttLd+cfB1ZIAyvsfbUepFNW6yPzv0bC3OLEVVIePXXqc2m6lqsItYUJ/Z9kiH8+fg38rpQz5kp5RukWDNP3+ql2xbt1/yU/geyPTxI08+2KTJprbyXRfvUBER8ukP/hLmsBrR/53dbY=,iv:zSW+bj7WeYlh+0cTkZSBg4JF9olY7RcyxqF23LOb1tc=,tag:Xu0jR8QDvrM/S0b0d/R+aw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}

--- a/non-critical-infra/secrets/storagebox-ssh-key.caliban
+++ b/non-critical-infra/secrets/storagebox-ssh-key.caliban
@@ -1,0 +1,32 @@
+{
+	"data": "ENC[AES256_GCM,data:Rn47V/K87NVhlFJp+8Mj7G12w51aDUgPOQfeIIhR2vXC2U4488LoMgkq08wULWXiomsy9EfSA2wxGGAOFlyzTg86GDK/mfq1/bJGs5XopODojcB7G8R2zAqodCW+xmlnVJGV+V8IvVMkCAWZNyjTlI1C78QpqSNAyow47UjeO9ZLxWGic30BhT3YddnQML6pLWGwzimYa7xVxt4gnc9/Gq+PHxWdF4mUM4nuYdjJKxOC9R+xiY7s4NZxIkwiBTA6xomm5Wckf4WuKUCKpPD4ZGX4cTj3MXtAlKWWKPRHkY84YHxtHAiCRVJlkeZNPYEyJsUDrJ8KWDhELUb42BDSCHn8xHBuxkyffAFdhCAJztP2uPdLd+Txow2kf3Eh+YbcP1tAPKl72Tygq8EZImE8fGKMf7M+E80KN7fFjxVUfQyLcFLwkFgWpmOZFR9erJdJjBCfz1olj27e/5l340SIc0RgY3yKu3WOyXzdMyuua4ZfbYjokzSEkJXhnp0oIP8m+c8qy51VbvF8Po1inuB9,iv:6vxychlAMRy65WUacdiuSrjmqytK71E5qDgBrUSQvvE=,tag:jqFAPHjjmN5UOWROSWhUkQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnTkhLN2YrWi84SW5SanNw\nMWxsdGNPT3kwWnFWUDE2WkQ2Y1VXSXdGbkdNCjBndEExZWEyTmhaQUY1YTdOcm90\naHp3ZjVGRmxCNkN2aUpwMi9jdkJhb00KLS0tIGFNRVhrdWd4M2tITHE4ckc2S214\naW1HTE9sOGVndllSc1JmNFU0dlhTUWMKWWAnfNKuEZAZVm8XLNwsTD8BYIduft/T\niE6iAEImAYAhh6ta3noy4SBRDDULtjrHWWe/cnBANSairr7/mURb5w==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTUU1Ib3pIbFZxaVNQbzdO\neTlidUg3djhSMVYrVnNYWW40WjlZUjFISW1ZCkluQmtCTStUNklFZUd3S2JraXl0\nYUtUYlRBTCtIbFAyS09KK1VSU1RUOEUKLS0tIEVFVGM4azZvMHhHMWl2N0cyMktp\nVkorcFZZQSt4V3k2M2gzM25NRWVjVVkKaqOmksXnveU7Sqa90X9RQtHzBAZCYC5Y\nJXfhmmIb/kNu62gvgErM+uel6ptg7uA4STSy+uD9Hr1C+v+sLOiCAg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArR0toVUJRclJJUG4yNUE0\nb2YxdHorTnpHT2UrQVhkbkEyc3AvU1JJdlRFCk9xcEltUFlVTllRb0Ivc3c0b1Rp\naGsrQkI5V2NYRndaVDFGYzdqWG9Pc2cKLS0tIFlrWmd4NWlMV2NkRFo4aERyY05t\nbHd6QVg1ZElyRHIrYk1XaHl5VmxERzQKDT+Xsh7CTmSkQnanpFC2XwE1V1FmOHKy\nmPWh5hDQ3MZSK1x4WSsR+e0D1n6Amc20sa8xdrJ8k29qpN/1cm5PQA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6Mm94bk92azhCQjk4NWhH\nNHNnblk1WDkxbzFMRDR3QkVOSjEzcHo4T2h3Cm53eVlmZGNXQVJUQU42SWtxeGZ1\nK1oxdXdYUmhRNTJjM3d4N3lTazJTSGsKLS0tIFh2aitRZlc2ZW44TEY3NnMycHFI\nWU5TTEFIMFBuaktnWHNOSzlINjlBbGMKXmeO3Uinr4BElDXUJ7wI6Ac7ZF6lTWxQ\nHb5byJRcd0pki/o/SZNV668eENUWKTRp7/PrY6p11cAHbrG0WmDggg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2024-01-29T14:55:03Z",
+		"mac": "ENC[AES256_GCM,data:qU7d9PVk0MYn94O6r+7dJmtvzezW3Acj31hCErf/9qiqXHtsOPlX9ubzSXWTrctVtSmty6IUUjLzPTz1a/vppTKCupaeEhHNZlGkBDXE5d/xJKymM5cE9g067xDI6dwXorYZzKK+SAemJtkzTDIpQNxt9R/pyJVXiNDfG7OqEbc=,iv:EwWx1spY/tAgVuLdSjVhq+x7d3gSslAzXFtcEEhGUgo=,tag:l8gwt+wXZY6fFdraZb/sJQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}


### PR DESCRIPTION
Adds a backup module, encapsulating borgbackup, and configures the storagebox we have for caliban.nixos.org.

The backup module will not be enabled until any path is added in to `services.backup.includes`, but I tested it, and it works.