### PR TITLE
prometheus-nixos-exporter: add nix 2.19.0 compat

### DIFF
--- a/modules/prometheus/default.nix
+++ b/modules/prometheus/default.nix
@@ -1,4 +1,8 @@
 { pkgs, ... }:
+
+let
+  prometheus-nixos-exporter = pkgs.callPackage ./nixos-exporter {};
+in
 {
   networking.firewall.allowedTCPPorts = [
     9100 # node-exporter
@@ -19,7 +23,6 @@
     ${./system-version-exporter.sh} | ${pkgs.moreutils}/bin/sponge system-version.prom
   '';
 
-
   systemd.services.prometheus-nixos-exporter = {
     wantedBy = [ "multi-user.target" ];
     after = [ "network.target" ];
@@ -27,14 +30,7 @@
     serviceConfig = {
       Restart = "always";
       RestartSec = "60s";
-      ExecStart = let
-          python = pkgs.python3.withPackages (ps: with ps; [
-            packaging
-            prometheus-client
-          ]);
-        in ''
-          ${python}/bin/python ${./nixos-exporter.py}
-      '';
+      ExecStart = "${prometheus-nixos-exporter}/bin/prometheus-nixos-exporter";
     };
   };
 }

--- a/modules/prometheus/default.nix
+++ b/modules/prometheus/default.nix
@@ -28,8 +28,9 @@
       Restart = "always";
       RestartSec = "60s";
       ExecStart = let
-          python = pkgs.python3.withPackages (p: [
-            p.prometheus_client
+          python = pkgs.python3.withPackages (ps: with ps; [
+            packaging
+            prometheus-client
           ]);
         in ''
           ${python}/bin/python ${./nixos-exporter.py}

--- a/modules/prometheus/nixos-exporter.py
+++ b/modules/prometheus/nixos-exporter.py
@@ -33,24 +33,29 @@ class NixosSystemCollector:
         current_system = GaugeMetricFamily(
             "nixos_current_system_time_seconds",
             "The time the system's current generation was registered in the Nix database.",
-            labels=["version_id"]
+            labels=["version_id"],
         )
-        current_system.add_metric([self.get_version_id("/run/current-system")],
-                                  self.get_time("/run/current-system"))
+        current_system.add_metric(
+            [self.get_version_id("/run/current-system")],
+            self.get_time("/run/current-system"),
+        )
         yield current_system
 
         booted_system = GaugeMetricFamily(
             "nixos_booted_system_time_seconds",
             "The time the system's booted generation was registered in the Nix database.",
-            labels=["version_id"]
+            labels=["version_id"],
         )
-        booted_system.add_metric([self.get_version_id("/run/booted-system")], self.get_time("/run/booted-system"))
+        booted_system.add_metric(
+            [self.get_version_id("/run/booted-system")],
+            self.get_time("/run/booted-system"),
+        )
         yield booted_system
 
     def get_version_id(self, path):
         result = subprocess.run(
-            [ "bash", "-c", f"source {path}/etc/os-release; echo $VERSION_ID" ],
-            stdout=subprocess.PIPE
+            ["bash", "-c", f"source {path}/etc/os-release; echo $VERSION_ID"],
+            stdout=subprocess.PIPE,
         )
         if result.returncode == 0:
             return result.stdout.decode("utf-8").strip()
@@ -74,13 +79,13 @@ class NixosSystemCollector:
 
         return 0
 
+
 registry = CollectorRegistry()
 registry.register(NixosSystemCollector())
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Start up the server to expose the metrics.
     start_http_server(9300, registry=registry)
 
     while True:
         time.sleep(100000)
-

--- a/modules/prometheus/nixos-exporter/default.nix
+++ b/modules/prometheus/nixos-exporter/default.nix
@@ -1,0 +1,20 @@
+{ python3Packages }:
+
+with python3Packages;
+
+buildPythonApplication {
+  pname = "prometheus-nixos-exporter";
+  version = "0.0";
+  pyproject = true;
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    packaging
+    prometheus-client
+  ];
+}

--- a/modules/prometheus/nixos-exporter/prometheus_nixos_exporter/__main__.py
+++ b/modules/prometheus/nixos-exporter/prometheus_nixos_exporter/__main__.py
@@ -80,12 +80,16 @@ class NixosSystemCollector:
         return 0
 
 
-registry = CollectorRegistry()
-registry.register(NixosSystemCollector())
+def main():
+    registry = CollectorRegistry()
+    registry.register(NixosSystemCollector())
 
-if __name__ == "__main__":
     # Start up the server to expose the metrics.
     start_http_server(9300, registry=registry)
 
     while True:
         time.sleep(100000)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/prometheus/nixos-exporter/pyproject.toml
+++ b/modules/prometheus/nixos-exporter/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prometheus-nixos-exporter"
+version = "0.0.0"
+description = "Export informations about booted aund current NixOS generation"
+dependencies = [
+  "packaging",
+  "prometheus-client",
+]
+
+[project.scripts]
+prometheus-nixos-exporter = "prometheus_nixos_exporter.__main__:main"


### PR DESCRIPTION
The output of `nix path-info --json` changed from a list to an object in nix 2.19.0.

Add a simple version detection, so we can support both output formats.

Fixes: #346