### PR TITLE
delft: update network configuration

### DIFF
--- a/delft/common.nix
+++ b/delft/common.nix
@@ -64,6 +64,17 @@ with lib;
   networking.firewall.allowPing = true;
   networking.firewall.allowedTCPPorts = [ 10050 ];
 
+  services.resolved = {
+    enable = true;
+    fallbackDns = [
+      # https://docs.hetzner.com/de/dns-console/dns/general/recursive-name-servers/
+      "185.12.64.1"
+      "185.12.64.2"
+      "2a01:4ff:ff00::add:1"
+      "2a01:4ff:ff00::add:2"
+    ];
+  };
+
   # Bump the open files limit so that non-root users can run NixOS VM
   # tests (Samba opens lot of files).
   security.pam.loginLimits =

--- a/delft/common.nix
+++ b/delft/common.nix
@@ -57,6 +57,8 @@ with lib;
       allowed-uris = https://github.com/ https://git.savannah.gnu.org/ github:
     '';
 
+  networking.useDHCP = false;
+
   networking.firewall.enable = true;
   networking.firewall.rejectPackets = true;
   networking.firewall.allowPing = true;

--- a/delft/eris-physical.nix
+++ b/delft/eris-physical.nix
@@ -18,29 +18,6 @@
   imports = [
     {
       config = {
-        networking = {
-          defaultGateway = "138.201.32.65";
-          interfaces.eth0 = {
-            ipAddress = "138.201.32.77";
-            prefixLength = 26;
-          };
-          localCommands = ''
-            ip -6 addr add '2a01:4f8:171:33cc::/64' dev 'eth0' || true
-            ip -4 route change '138.201.32.64/26' via '138.201.32.65' dev 'eth0' || true
-            ip -6 route add default via 'fe80::1' dev eth0 || true
-          '';
-          nameservers = [
-            "213.133.98.98"
-            "213.133.99.99"
-            "213.133.100.100"
-            "2a01:4f8:0:a0a1::add:1010"
-            "2a01:4f8:0:a102::add:9999"
-            "2a01:4f8:0:a111::add:9898"
-          ];
-        };
-        services.udev.extraRules = ''
-          ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="90:1b:0e:91:c3:67", NAME="eth0"
-        '';
         users.extraUsers.root.openssh.authorizedKeys.keys = [
           "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIXnddtPlqCgmGK3yE48/eoUke4u2O2SIin6kUp4T1eZ NixOps client key of eris"
         ];

--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -12,6 +12,7 @@ in
     ./eris/github-project-monitor.nix
     ./eris/alertmanager-matrix-forwarder.nix
     ./eris/channel-monitor.nix
+    ./eris/network.nix
   ];
 
   system.stateVersion = "18.03";

--- a/delft/eris/network.nix
+++ b/delft/eris/network.nix
@@ -1,0 +1,24 @@
+{
+  systemd.network = {
+    enable = true;
+    networks = {
+      "30-enp0s31f6" = {
+        matchConfig = {
+          MACAddress = "90:1b:0e:91:c3:67";
+          Type = "ether";
+        };
+        linkConfig.RequiredForOnline = true;
+        networkConfig.Description = "WAN";
+        address = [
+          "138.201.32.77/26"
+          "2a01:4f8:171:33cc::1/64"
+        ];
+        routes = [ {
+          routeConfig.Gateway = "138.201.32.65";
+        } {
+          routeConfig.Gateway = "fe80::1";
+        } ];
+      };
+    };
+  };
+}

--- a/delft/haumea-physical.nix
+++ b/delft/haumea-physical.nix
@@ -18,29 +18,6 @@
   imports = [
     {
       config = {
-        networking = {
-          defaultGateway = { address = "46.4.89.193"; interface = "eth0"; };
-          defaultGateway6 = { address = "fe80::1"; interface = "eth0"; };
-          interfaces.eth0 = {
-            ipv4.addresses = [
-              { address = "46.4.89.205"; prefixLength = 27; }
-            ];
-            ipv6.addresses = [
-              { address = "2a01:4f8:173:a02::"; prefixLength = 64; }
-            ];
-          };
-          nameservers = [
-            "213.133.98.98"
-            "213.133.99.99"
-            "213.133.100.100"
-            "2a01:4f8:0:a0a1::add:1010"
-            "2a01:4f8:0:a102::add:9999"
-            "2a01:4f8:0:a111::add:9898"
-          ];
-        };
-        services.udev.extraRules = ''
-          ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="a8:a1:59:04:71:f5", NAME="eth0"
-        '';
         users.extraUsers.root.openssh.authorizedKeys.keys = [
           "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN+xcwa7Oj8At7n8gHQu7UXArxCJSQZgMaspfkyLbP1j NixOps client key of haumea"
         ];

--- a/delft/haumea.nix
+++ b/delft/haumea.nix
@@ -5,6 +5,7 @@
     [ ./common.nix
       # ./datadog.nix # error: psycopg2-2.9.1 not supported for interpreter python2.7
       ./fstrim.nix
+      ./haumea/network.nix
     ];
 
   system.stateVersion = "14.12";

--- a/delft/haumea/network.nix
+++ b/delft/haumea/network.nix
@@ -1,0 +1,24 @@
+{
+  systemd.network = {
+    enable = true;
+    networks = {
+      "30-enp35s0" = {
+        matchConfig = {
+          MACAddress = "a8:a1:59:04:71:f5";
+          Type = "ether";
+        };
+        address = [
+          "46.4.89.205/27"
+          "2a01:4f8:212:41c9::1/64"
+        ];
+        routes = [ {
+          routeConfig.Gateway = "46.4.89.193";
+        } {
+          routeConfig.Gateway = "fe80::1";
+        } ];
+        networkConfig.Description = "WAN";
+        linkConfig.RequiredForOnline = true;
+      };
+    };
+  };
+}

--- a/delft/rhea/configuration.nix
+++ b/delft/rhea/configuration.nix
@@ -3,6 +3,7 @@
   imports =
     [ ./hardware-configuration.nix
       ./hetzner.nix
+      ./network.nix
       ../common.nix
       ../hydra.nix
       ../hydra-proxy.nix

--- a/delft/rhea/hetzner.nix
+++ b/delft/rhea/hetzner.nix
@@ -1,36 +1,4 @@
 {
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
-
-  networking.hostId = "9cd372da";
-  networking.useNetworkd = true;
-  systemd.network.networks."40-enp7s0" = {
-    matchConfig = {
-      MACAddress = "50:eb:f6:22:f0:3a";
-    };
-
-    addresses = [
-      {
-        addressConfig.Address = "5.9.122.43/27";
-      }
-      {
-        addressConfig.Address = "2a01:4f8:162:71eb::/64";
-      }
-    ];
-    routes = [
-      {
-        routeConfig.Gateway = "5.9.122.33";
-      }
-      {
-        routeConfig.Gateway = "fe80::1";
-      }
-    ];
-
-    dns = [
-      "185.12.64.1"
-      "185.12.64.2"
-      "2a01:4ff:ff00::add:1"
-      "2a01:4ff:ff00::add:2"
-    ];
-  };
 }

--- a/delft/rhea/hetzner.nix
+++ b/delft/rhea/hetzner.nix
@@ -4,7 +4,6 @@
 
   networking.hostId = "9cd372da";
   networking.useNetworkd = true;
-  networking.useDHCP = false;
   systemd.network.networks."40-enp7s0" = {
     matchConfig = {
       MACAddress = "50:eb:f6:22:f0:3a";

--- a/delft/rhea/network.nix
+++ b/delft/rhea/network.nix
@@ -1,0 +1,24 @@
+{
+  networking.hostId = "9cd372da";
+
+  systemd.network = {
+    enable = true;
+    networks."40-enp7s0" = {
+      matchConfig = {
+        MACAddress = "50:eb:f6:22:f0:3a";
+        Type = "ether";
+      };
+      linkConfig.RequiredForOnline = "routable";
+      networkConfig.Description = "WAN";
+      address = [
+        "5.9.122.43/27"
+        "2a01:4f8:162:71eb::/64"
+      ];
+      routes = [ {
+        routeConfig.Gateway = "5.9.122.33";
+      } {
+        routeConfig.Gateway = "fe80::1";
+      } ];
+    };
+  };
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -22,6 +22,11 @@ locals {
       value    = "138.201.32.77"
     },
     {
+      hostname = "eris.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:171:33cc::1"
+    },
+    {
       hostname = "haumea.nixos.org"
       type     = "A"
       value    = "46.4.89.205"


### PR DESCRIPTION
- Migrates network configuration to networkd 
- Drops udev rules for network interface names, returns to predictable interface names
  - Should be impact-free, since we don't match the interface name anyway
- Migrates DNS configuration to resolved
- Moves eris' IPv6 address from the network address
- Sets up IPv6 DNS for eris